### PR TITLE
add dynamic-plugins-registry-auth secret

### DIFF
--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -186,6 +186,11 @@ data:
                 defaultMode: 420
                 optional: true
                 secretName: dynamic-plugins-npmrc
+            - name: dynamic-plugins-registry-auth
+              secret:
+                defaultMode: 416
+                optional: true
+                secretName: dynamic-plugins-registry-auth
             - emptyDir: {}
               name: npmcacache
           initContainers:
@@ -214,6 +219,9 @@ data:
                   name: dynamic-plugins-npmrc
                   readOnly: true
                   subPath: .npmrc
+                - mountPath: /opt/app-root/src/.config/containers
+                  name: dynamic-plugins-registry-auth
+                  readOnly: true
                 - mountPath: /opt/app-root/src/.npm/_cacache
                   name: npmcacache
               workingDir: /opt/app-root/src

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -33,6 +33,11 @@ spec:
             defaultMode: 420
             optional: true
             secretName: dynamic-plugins-npmrc
+        - name: dynamic-plugins-registry-auth
+          secret:
+            defaultMode: 416
+            optional: true
+            secretName: dynamic-plugins-registry-auth
         - emptyDir: {}
           name: npmcacache
       initContainers:
@@ -61,6 +66,9 @@ spec:
               name: dynamic-plugins-npmrc
               readOnly: true
               subPath: .npmrc
+            - mountPath: /opt/app-root/src/.config/containers
+              name: dynamic-plugins-registry-auth
+              readOnly: true
             - mountPath: /opt/app-root/src/.npm/_cacache
               name: npmcacache
           workingDir: /opt/app-root/src

--- a/integration_tests/rhdh-config_test.go
+++ b/integration_tests/rhdh-config_test.go
@@ -54,23 +54,24 @@ var _ = When("create default backstage", func() {
 			g.Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			_, initCont := model.DynamicPluginsInitContainer(deploy.Spec.Template.Spec.InitContainers)
 			//deploy.Spec.Template.Spec.InitContainers[0]
-			g.Expect(initCont.VolumeMounts).To(HaveLen(4))
+			g.Expect(initCont.VolumeMounts).To(HaveLen(5))
 			g.Expect(initCont.VolumeMounts[0].MountPath).To(Equal("/dynamic-plugins-root"))
 			g.Expect(initCont.VolumeMounts[0].SubPath).To(BeEmpty())
 			g.Expect(initCont.VolumeMounts[1].MountPath).To(Equal("/opt/app-root/src/.npmrc.dynamic-plugins"))
 			g.Expect(initCont.VolumeMounts[1].SubPath).To(Equal(".npmrc"))
-			g.Expect(initCont.VolumeMounts[2].MountPath).To(Equal("/opt/app-root/src/.npm/_cacache"))
-			g.Expect(initCont.VolumeMounts[2].SubPath).To(BeEmpty())
-			g.Expect(initCont.VolumeMounts[3].MountPath).To(Equal("/opt/app-root/src/dynamic-plugins.yaml"))
-			g.Expect(initCont.VolumeMounts[3].SubPath).To(Equal("dynamic-plugins.yaml"))
-			g.Expect(initCont.VolumeMounts[3].Name).
+			g.Expect(initCont.VolumeMounts[2].MountPath).To(Equal("/opt/app-root/src/.config/containers"))
+			g.Expect(initCont.VolumeMounts[3].MountPath).To(Equal("/opt/app-root/src/.npm/_cacache"))
+			g.Expect(initCont.VolumeMounts[3].SubPath).To(BeEmpty())
+			g.Expect(initCont.VolumeMounts[4].MountPath).To(Equal("/opt/app-root/src/dynamic-plugins.yaml"))
+			g.Expect(initCont.VolumeMounts[4].SubPath).To(Equal("dynamic-plugins.yaml"))
+			g.Expect(initCont.VolumeMounts[4].Name).
 				To(Equal(utils.GenerateVolumeNameFromCmOrSecret(model.DynamicPluginsDefaultName(backstageName))))
-			g.Expect(initCont.VolumeMounts[3].SubPath).To(Equal(model.DynamicPluginsFile))
+			g.Expect(initCont.VolumeMounts[4].SubPath).To(Equal(model.DynamicPluginsFile))
 
 			g.Expect(initCont.Env[0].Name).To(Equal("NPM_CONFIG_USERCONFIG"))
 			g.Expect(initCont.Env[0].Value).To(Equal("/opt/app-root/src/.npmrc.dynamic-plugins"))
 
-			g.Expect(deploy.Spec.Template.Spec.Volumes).To(HaveLen(5))
+			g.Expect(deploy.Spec.Template.Spec.Volumes).To(HaveLen(6))
 			g.Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
 			mainCont := deploy.Spec.Template.Spec.Containers[0]
 			g.Expect(mainCont.Args).To(HaveLen(4))

--- a/pkg/model/deployment_test.go
+++ b/pkg/model/deployment_test.go
@@ -122,7 +122,7 @@ spec:
        pod: backstage
    spec:
      containers:
-       - name: sidecar 
+       - name: sidecar
          image: my-image:1.0.0
        - name: backstage-backend
          resources:
@@ -160,13 +160,13 @@ spec:
 	assert.Equal(t, "257Mi", model.backstageDeployment.container().Resources.Requests.Memory().String())
 
 	// volumes
-	// dynamic-plugins-root, dynamic-plugins-npmrc, my-vol
-	assert.Equal(t, 3, len(model.backstageDeployment.deployment.Spec.Template.Spec.Volumes))
+	// dynamic-plugins-root, dynamic-plugins-npmrc, dynamic-plugins-auth, my-vol
+	assert.Equal(t, 4, len(model.backstageDeployment.deployment.Spec.Template.Spec.Volumes))
 	assert.Equal(t, "dynamic-plugins-root", model.backstageDeployment.deployment.Spec.Template.Spec.Volumes[0].Name)
 	// overrides StorageClassName
 	assert.Equal(t, "special", *model.backstageDeployment.deployment.Spec.Template.Spec.Volumes[0].Ephemeral.VolumeClaimTemplate.Spec.StorageClassName)
 	// adds new volume
-	assert.Equal(t, "my-vol", model.backstageDeployment.deployment.Spec.Template.Spec.Volumes[2].Name)
+	assert.Equal(t, "my-vol", model.backstageDeployment.deployment.Spec.Template.Spec.Volumes[3].Name)
 }
 
 // to remove when stop supporting v1alpha1

--- a/pkg/model/dynamic-plugins_test.go
+++ b/pkg/model/dynamic-plugins_test.go
@@ -92,15 +92,17 @@ func TestDefaultDynamicPlugins(t *testing.T) {
 	assert.NotNil(t, model.backstageDeployment)
 	//dynamic-plugins-root
 	//dynamic-plugins-npmrc
+	//dynamic-plugins-auth
 	//vol-default-dynamic-plugins
-	assert.Equal(t, 3, len(model.backstageDeployment.deployment.Spec.Template.Spec.Volumes))
+	assert.Equal(t, 4, len(model.backstageDeployment.deployment.Spec.Template.Spec.Volumes))
 
 	ic := initContainer(model)
 	assert.NotNil(t, ic)
 	//dynamic-plugins-root
 	//dynamic-plugins-npmrc
+	//dynamic-plugins-auth
 	//vol-default-dynamic-plugins
-	assert.Equal(t, 3, len(ic.VolumeMounts))
+	assert.Equal(t, 4, len(ic.VolumeMounts))
 
 }
 
@@ -127,9 +129,10 @@ func TestDefaultAndSpecifiedDynamicPlugins(t *testing.T) {
 	assert.NotNil(t, ic)
 	//dynamic-plugins-root
 	//dynamic-plugins-npmrc
+	//dynamic-plugins-auth
 	//vol-dplugin
-	assert.Equal(t, 3, len(ic.VolumeMounts))
-	assert.Equal(t, utils.GenerateVolumeNameFromCmOrSecret("dplugin"), ic.VolumeMounts[2].Name)
+	assert.Equal(t, 4, len(ic.VolumeMounts))
+	assert.Equal(t, utils.GenerateVolumeNameFromCmOrSecret("dplugin"), ic.VolumeMounts[3].Name)
 }
 
 func TestDynamicPluginsFailOnArbitraryDepl(t *testing.T) {

--- a/pkg/model/testdata/janus-deployment.yaml
+++ b/pkg/model/testdata/janus-deployment.yaml
@@ -28,6 +28,11 @@ spec:
             defaultMode: 420
             optional: true
             secretName: dynamic-plugins-npmrc
+        - name: dynamic-plugins-registry-auth
+          secret:
+            defaultMode: 416
+            optional: true
+            secretName: dynamic-plugins-registry-auth
       initContainers:
         - command:
             - ./install-dynamic-plugins.sh
@@ -45,6 +50,9 @@ spec:
               name: dynamic-plugins-npmrc
               readOnly: true
               subPath: .npmrc
+            - mountPath: /opt/app-root/src/.config/containers
+              name: dynamic-plugins-registry-auth
+              readOnly: true
           workingDir: /opt/app-root/src
 
       containers:


### PR DESCRIPTION
For secure container registry we need a `auth.json` file that contains auth tokens. The file is stored as a secret like

```
oc create secret generic dynamic-plugins-registry-auth --from-file=~/.config/containers/auth.json
```

It is then picked up by `skopeo` during the dynamic plugin install process.

Accompanying PR for dynamic plugins:

https://github.com/janus-idp/backstage-showcase/pull/1479
https://github.com/redhat-developer/rhdh-chart/pull/41