### PR TITLE
[1.2.x] ci: Fix image repo location when pushing operator images

### DIFF
--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -108,7 +108,7 @@ jobs:
 
           # now copy images from local cache to quay, using 0.0.1-next-f00cafe, 0.0.1-next, and next tags
           for image in operator operator-bundle operator-catalog; do
-            podman push quay.io/janus-idp/${image}:${VERSION} -q
-            skopeo --insecure-policy copy --all docker://quay.io/janus-idp/${image}:${VERSION} docker://quay.io/janus-idp/${image}:${VERSION}-${{ env.SHORT_SHA }}
-            skopeo --insecure-policy copy --all docker://quay.io/janus-idp/${image}:${VERSION} docker://quay.io/janus-idp/${image}:${latestNext}
+            podman push quay.io/rhdh-community/${image}:${VERSION} -q
+            skopeo --insecure-policy copy --all docker://quay.io/rhdh-community/${image}:${VERSION} docker://quay.io/rhdh-community/${image}:${VERSION}-${{ env.SHORT_SHA }}
+            skopeo --insecure-policy copy --all docker://quay.io/rhdh-community/${image}:${VERSION} docker://quay.io/rhdh-community/${image}:${latestNext}
           done


### PR DESCRIPTION
## Description

The nightly Workflow passes but with a warning on 1.2.x about a missing [`quay.io/rhdh-community/operator:0.2.3`](http://quay.io/rhdh-community/operator:0.2.3) image tag. Example: https://github.com/redhat-developer/rhdh-operator/actions/runs/10624194874

![image](https://github.com/user-attachments/assets/8af8cb70-ad53-425b-9d07-ab3bf180e4ec)

These warnings can be expected since CI tags purposely expire after a few weeks. But in this specific case, we should have recent image builds from the 1.2.x branch because that branch has been updated recently.
It looks like the job building and pushing that image on 1.2.x did not pass: https://github.com/redhat-developer/rhdh-operator/actions/runs/10620716428/job/29441095997

```
Successfully tagged quay.io/rhdh-community/operator-catalog:0.2.3
28bce337c49efa5435c24f607dad615f4bd0ffa4f026175b896dc81ce0e43749
+ for image in operator operator-bundle operator-catalog
+ podman push quay.io/janus-idp/operator:0.2.3 -q
Error: quay.io/janus-idp/operator:0.2.3: image not known
```

## Which issue(s) does this PR fix or relate to

- Fixes issues with the image building workflow: https://github.com/redhat-developer/rhdh-operator/actions/runs/10620716428/job/29441095997
- Fixes https://issues.redhat.com/browse/RHIDP-3704

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer

&mdash;

/cc @nickboldt 