### PR TITLE
chore(deps): disable kustomize updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,9 @@
   "constraints": {
     "go": "1.21"
   },
+  "kustomize": {
+    "enabled": false
+  },   
   "packageRules": [
     {
       "description": "Do NOT generate PRs to pin or apply digests to dockerfiles",


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
Disable renovate updates to kustomize because `newTags` are not being updated properly.  They are being bumped to the latest minor version in each branch which is not what we want.   Seems like updates are being done manually now today.  This change will make it easier to merge the renovate PRs

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_
https://issues.redhat.com/browse/RHIDP-4007

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
