### PR TITLE
ci: Validate Renovate config in CI

### DIFF
--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -1,0 +1,33 @@
+# Copyright 2023 The Janus IDP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: PR Renovate Config Validator
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json'
+    # Renovate always uses the config from the repository default branch
+    # https://docs.renovatebot.com/configuration-options/
+    branches: [ 'main' ]
+
+jobs:
+  renovate-config-validator:
+    runs-on: ubuntu-latest
+    name: Renovate Config Validator
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: Validate config
+        # See https://docs.renovatebot.com/config-validation/
+        run: |
+          npx --yes --package renovate -- renovate-config-validator --strict .github/renovate.json


### PR DESCRIPTION
## Description

While reviewing https://github.com/redhat-developer/rhdh-operator/pull/185, I thought it could help to check the Renovate config file in CI (for PRs that modify the config file). And I quickly found that there is a standalone tool from Renovate that could allow us to enforce such checks - see https://docs.renovatebot.com/config-validation/.
(If that makes sense).

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer

If you have the [`act`](https://github.com/nektos/act) and [`gh`](https://cli.github.com/) CLIs locally, you can run this job locally with `gh act -j renovate-config-validator`

/cc @kim-tsao @nickboldt 