### PR TITLE
ci: Run E2E tests against the `1.3.x` branch

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, 1.2.x, 1.1.x ]
+        branch: [ main, 1.3.x, 1.2.x, 1.1.x ]
         test_upgrade: [ 'true', 'false' ]
         exclude:
           - branch: 1.1.x # Testing upgrade from 1.1.x


### PR DESCRIPTION
## Description
This includes the `1.3.x` branch in the branches against which the E2E nightly tests should run.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer

&mdash;