### PR TITLE
ci: Fix the 'Upgrade' E2E tests on `main` [RHIDP-4066]

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -55,10 +55,11 @@ jobs:
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # v0.0.18
 
-      - name: Run E2E tests (Operator Upgrade path)
+      - name: Run E2E tests (RHDH Operator Upgrade path)
         if: ${{ matrix.test_upgrade == 'true' && steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         env:
           BACKSTAGE_OPERATOR_TESTS_PLATFORM: minikube
+          PROFILE: 'rhdh'
           IMG: ${{ env.OPERATOR_IMAGE }}
         run: make test-e2e-upgrade
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ gosec.sarif
 catalog_mirror.log
 manifests-rhdh-index-*
 rhdh-operator-*.yaml
+# manifests used for the upgrade path E2E tests
+!tests/e2e/testdata/rhdh-operator-*.yaml
 rhdh-disconnected-install/
 rhdh-disconnected-install.Dockerfile
 

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Operator upgrade with existing instances", func() {
 		const managerPodLabel = "control-plane=controller-manager"
 		const crName = "my-backstage-app"
 
-		// 0.1.3 is the version of the operator in the 1.1.x branch
-		var fromDeploymentManifest = filepath.Join(projectDir, "tests", "e2e", "testdata", "backstage-operator-0.1.3.yaml")
+		// 0.1 is the version of the operator in the 1.1.x branch
+		var fromDeploymentManifest = filepath.Join(projectDir, "tests", "e2e", "testdata", "rhdh-operator-1.1.yaml")
 
 		BeforeEach(func() {
 			if testMode != defaultDeployTestMode {

--- a/tests/e2e/testdata/rhdh-operator-1.1.yaml
+++ b/tests/e2e/testdata/rhdh-operator-1.1.yaml
@@ -1,18 +1,28 @@
+# /!\ EDIT ONLY IF NECESSARY
 #
 # Generated using `make deployment-manifest` against the 1.1.x branch.
 # Used to test the upgrade paths of the operator.
+# So this needs to reflect exactly what a user
+# would get if they deploy that version of the operator.
 #
+# Steps to generate an RHDH Operator manifest from the source branch:
+# 1. make deployment-manifest
+# 2. sed -i "s/backstage-operator/rhdh-operator/g" tests/e2e/testdata/rhdh-operator-*.yaml
+# 3. sed -i "s/backstage-system/rhdh-operator/g" tests/e2e/testdata/rhdh-operator-*.yaml
+# 4. sed -i "s/backstage-controller-manager/rhdh-controller-manager/g" tests/e2e/testdata/rhdh-operator-*.yaml
+#
+
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: system
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: namespace
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
     control-plane: controller-manager
   name: rhdh-operator
 ---
@@ -288,12 +298,12 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/part-of: backstage-operator
-  name: backstage-controller-manager
+    app.kubernetes.io/part-of: rhdh-operator
+  name: rhdh-controller-manager
   namespace: rhdh-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -301,11 +311,11 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: role
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
   name: backstage-leader-election-role
   namespace: rhdh-operator
 rules:
@@ -441,11 +451,11 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
   name: backstage-metrics-reader
 rules:
   - nonResourceURLs:
@@ -458,11 +468,11 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: proxy-role
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
   name: backstage-proxy-role
 rules:
   - apiGroups:
@@ -483,11 +493,11 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
   name: backstage-leader-election-rolebinding
   namespace: rhdh-operator
 roleRef:
@@ -496,7 +506,7 @@ roleRef:
   name: backstage-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: backstage-controller-manager
+    name: rhdh-controller-manager
     namespace: rhdh-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -504,11 +514,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
   name: backstage-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -516,7 +526,7 @@ roleRef:
   name: backstage-manager-role
 subjects:
   - kind: ServiceAccount
-    name: backstage-controller-manager
+    name: rhdh-controller-manager
     namespace: rhdh-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -524,11 +534,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: proxy-rolebinding
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
   name: backstage-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -536,7 +546,7 @@ roleRef:
   name: backstage-proxy-role
 subjects:
   - kind: ServiceAccount
-    name: backstage-controller-manager
+    name: rhdh-controller-manager
     namespace: rhdh-operator
 ---
 apiVersion: v1
@@ -549,12 +559,10 @@ data:
     data:
       "app-config.backend-auth.default.yaml": |
         backend:
-        externalAccess:
-          - type: legacy
-            options:
-              subject: legacy-default-config
+          auth:
+            keys:
               # This is a default value, which you should change by providing your own app-config
-              secret: "pl4s3Ch4ng3M3"
+              - secret: "pl4s3Ch4ng3M3"
   db-secret.yaml: |
     apiVersion: v1
     kind: Secret
@@ -739,7 +747,7 @@ data:
                 - name: NPM_CONFIG_USERCONFIG
                   value: /opt/app-root/src/.npmrc.dynamic-plugins
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/rhdh/rhdh-hub-rhel9:next
+              image: quay.io/janus-idp/backstage-showcase:latest
               imagePullPolicy: IfNotPresent
               name: install-dynamic-plugins
               volumeMounts:
@@ -761,7 +769,7 @@ data:
           containers:
             - name: backstage-backend
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/rhdh/rhdh-hub-rhel9:next
+              image: quay.io/janus-idp/backstage-showcase:latest
               imagePullPolicy: IfNotPresent
               args:
                 - "--config"
@@ -856,13 +864,13 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
     control-plane: controller-manager
-  name: backstage-controller-manager-metrics-service
+  name: rhdh-controller-manager-metrics-service
   namespace: rhdh-operator
 spec:
   ports:
@@ -878,13 +886,13 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: backstage-operator
+    app.kubernetes.io/created-by: rhdh-operator
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: deployment
-    app.kubernetes.io/part-of: backstage-operator
+    app.kubernetes.io/part-of: rhdh-operator
     control-plane: controller-manager
-  name: backstage-controller-manager
+  name: rhdh-controller-manager
   namespace: rhdh-operator
 spec:
   replicas: 1
@@ -949,7 +957,7 @@ spec:
             - name: RELATED_IMAGE_postgresql
               value: quay.io/fedora/postgresql-15:latest
             - name: RELATED_IMAGE_backstage
-              value: quay.io/rhdh/rhdh-hub-rhel9:next
+              value: quay.io/rhdh/rhdh-hub-rhel9:1.1
           # TODO(asoro): Default image is 'quay.io/rhdh-community/operator:0.1.3' on 1.1.x,
           # but replaced by the one from RHDH, because the Janus-IDP image expires after 14d if not updated.
           image: quay.io/rhdh/rhdh-rhel9-operator:1.1
@@ -984,7 +992,7 @@ spec:
               name: default-config
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: backstage-controller-manager
+      serviceAccountName: rhdh-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - configMap:


### PR DESCRIPTION
## Description
More context in https://issues.redhat.com/browse/RHIDP-4066.

The content in `tests/e2e/testdata/backstage-operator-0.1.3.yaml`
used to deploy a "Backstage" operator as it looks like in 1.1.x,
but `main` now deploys an `RHDH` profile by default instead,
hence the mismatch.
Right now, we just want to test the upgrade using the default
behavior we had in the previous version, which is now
the 'RHDH' profile. So this renames the `testdata` manifest
to a more specific RHDH manifest, as this is what was actually
being expected anyway.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-4066

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
`make test-e2e-upgrade`  should work from the `main` branch.