### PR TITLE
chore(csv): switch to use OSE 4.16 image and...

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools
     certified: 'true'
-    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.4
+    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.4
     createdAt: "2023-03-20T16:11:34Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of an external database, and can
@@ -219,7 +219,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -253,8 +253,8 @@ spec:
                 - name: RELATED_IMAGE_postgresql
                   value: registry.redhat.io/rhel9/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
-                  value: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-hub-rhel9:1.4
-                image: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.4
+                  value: registry.redhat.io/rhdh/rhdh-hub-rhel9:1.4
+                image: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.4
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
### What does this PR do?

chore(csv): switch to use OSE 4.16 image and use reg.rh.io instead of reg-proxy internal images as Konflux doesn't like internal ones

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHIDP-3697 konflux RPA/test issues
https://issues.redhat.com/browse/RHIDP-2830 OSE 4.12 issues


### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.