### PR TITLE
Do not include the 1.1.x or 1.3.x branches in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
   "baseBranches": [
     "main",
     "/^release-1\\..*/",
-    "/^1\\..*\\.x/"
+    "/^1\\.2\\.x/"
   ],
   "constraints": {
     "go": "1.21"
@@ -83,7 +83,7 @@
       ],
       "baseBranches": [
         "/^release-1\\..*/",
-        "/^1\\..*\\.x/"
+        "/^1\\.2\\.x/"
       ],
       "automerge": false,
       "matchPackageNames": [
@@ -125,7 +125,7 @@
       ],
       "baseBranches": [
         "/^release-1\\..*/",
-        "/^1\\..*\\.x/"
+        "/^1\\.2\\.x/"
       ],
       "automerge": false,
       "matchPackageNames": [
@@ -163,7 +163,7 @@
       ],
       "baseBranches": [
         "/^release-1\\..*/",
-        "/^1\\..*\\.x/"
+        "/^1\\.2\\.x/"
       ],
       "automerge": false,
       "matchPackageNames": [


### PR DESCRIPTION
We are not going to do any more 1.1.x releases and we are now using the release-1.3 branch instead of 1.3.x so this pull request updates the configuration to not include those branches in the renovate generated pull requests.

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
