### PR TITLE
chore: [1.2.x] bump go-toolset to 1.21.13 in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #@follow_tag(registry.redhat.io/rhel9/go-toolset:latest)
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11-9.1726696856@sha256:04be9e51263ab743cbcb778921b23527a3e35d493136fd353a90670d84ac457f AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.13-2@sha256:81d135dc125dbda42e2eee82b0ec1f4bd0e98a66d7ee8393fee9755bf756f5f0 AS builder
 # hadolint ignore=DL3002
 USER 0
 ENV GOPATH=/go/


### PR DESCRIPTION
https://issues.redhat.com/browse/RHIDP-3173