### PR TITLE
chore: [release-1.3] bump go-toolset to 1.21.13 in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 #@follow_tag(registry.redhat.io/rhel9/go-toolset:latest)
 # https://registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11-9 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.13-2@sha256:81d135dc125dbda42e2eee82b0ec1f4bd0e98a66d7ee8393fee9755bf756f5f0 AS builder
 # hadolint ignore=DL3002
 USER 0
 ENV GOPATH=/go/


### PR DESCRIPTION
https://issues.redhat.com/browse/RHIDP-4031