### PR TITLE
chore(deps): make sure Renovate updates for OpenShift, Ginkgo and Gomega modules are disabled

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,8 @@
       ],
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "digest"
       ],
       "baseBranches": [
         "main"
@@ -79,7 +80,8 @@
         "go"
       ],
       "matchUpdateTypes": [
-        "patch"
+        "patch",
+        "digest"
       ],
       "baseBranches": [
         "/^release-1\\..*/",
@@ -95,8 +97,8 @@
       ]
     },
     {
-      "description": "ginkgo: minor and patch updates in main",
-      "enabled": true,
+      "description": "ginkgo: minor and patch updates in main (disabled until we support Go 1.22+, which is required since ginkgo 2.20.2)",
+      "enabled": false,
       "groupName": "ginkgo main",
       "matchDatasources": [
         "go"
@@ -114,8 +116,8 @@
       ]
     },
     {
-      "description": "ginkgo: patch updates only in 1.y",
-      "enabled": true,
+      "description": "ginkgo: patch updates only in 1.y (disabled until we support Go 1.22+, which is required since ginkgo 2.20.2)",
+      "enabled": false,
       "groupName": "ginkgo 1.y",
       "matchDatasources": [
         "go"
@@ -133,8 +135,8 @@
       ]
     },
     {
-      "description": "gomega: minor and patch updates in main",
-      "enabled": true,
+      "description": "gomega: minor and patch updates in main (disabled until we support Go 1.22+, which is required since gomega 1.34.2)",
+      "enabled": false,
       "groupName": "gomega main",
       "matchDatasources": [
         "go"
@@ -152,8 +154,8 @@
       ]
     },
     {
-      "description": "gomega: patch updates only in 1.y",
-      "enabled": true,
+      "description": "gomega: patch updates only in 1.y (disabled until we support Go 1.22+, which is required since gomega 1.34.2)",
+      "enabled": false,
       "groupName": "gomega 1.y",
       "matchDatasources": [
         "go"


### PR DESCRIPTION
## Description

We were getting a lot of noise from dependency updates for the following modules, which all require Go 1.22+ (not yet supported at the moment).
We usually end up manually closing the corresponding PRs, but new ones would be created as soon as there were new updates available.

The ones from `github.com/openshift/api` were creating most of the noise because we are depending on a pseudo-version mapped to a commit. So (from my observations) a new update PR would be created anytime there is a new commit in https://github.com/openshift/api/commits/master/.

- https://github.com/redhat-developer/rhdh-operator/pulls?q=sort%3Acreated-desc+is%3Apr+%22github.com%2Fopenshift%2Fapi%22+is%3Aclosed+
- https://github.com/redhat-developer/rhdh-operator/pulls?q=sort%3Acreated-desc+is%3Apr+%22github.com%2Fonsi%2Fginkgo%2Fv2%22+is%3Aclosed+

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer

Renovate Config Validator job passed: https://github.com/redhat-developer/rhdh-operator/actions/runs/11177943170/job/31074500161?pr=305
