### PR TITLE
chore: fix versions in bundle config and regenerate bundle [release-1.3]

### DIFF
--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-08-12T08:32:42Z"
+    createdAt: "2024-10-10T15:58:03Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -214,7 +214,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/rhdh/rhdh-hub-rhel9:next
-                image: quay.io/rhdh-community/operator:0.3.0
+                image: quay.io/rhdh-community/operator:0.3.1
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.3.0
+  newTag: 0.3.1
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
@@ -5,8 +5,8 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     operatorframework.io/suggested-namespace: backstage-system
-    skipRange: '>=0.0.1 <0.3.0'
-  name: backstage-operator.v0.3.0
+    skipRange: '>=0.0.1 <0.3.1'
+  name: backstage-operator.v0.3.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -55,4 +55,4 @@ spec:
     name: Red Hat Inc.
     url: https://www.redhat.com/
   replaces: backstage-operator.v0.2.0
-  version: 0.3.0
+  version: 0.3.1


### PR DESCRIPTION
## Description
This is an addendum to https://github.com/redhat-developer/rhdh-operator/pull/318.

I noticed that some Renovate PRs updating simple Github Actions resulted in changes in the bundle - see https://github.com/redhat-developer/rhdh-operator/pull/323/files#diff-350e6729515e8cd74b357c91611b67dc4e9723daa6863854a252fc6acea032cf

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer

/cc @nickboldt 