### PR TITLE
Fix the E2E tests against OCP [RHIDP-4499]

### DIFF
--- a/examples/rhdh-cr-with-app-configs.yaml
+++ b/examples/rhdh-cr-with-app-configs.yaml
@@ -1,43 +1,3 @@
-apiVersion: rhdh.redhat.com/v1alpha3
-kind: Backstage
-metadata:
-  name: bs-app-config
-spec:
-  database:
-    enableLocalDb: true
-  application:
-    replicas: 2
-    appConfig:
-      #mountPath:  /opt/app-root/src
-      configMaps:
-        - name: "my-backstage-config-backend-auth"
-        - name: "my-backstage-config-cm1"
-        - name: "my-backstage-config-cm2"
-          key: "app-config1-cm2.gh.yaml"
-    dynamicPluginsConfigMapName: "my-dynamic-plugins-config-cm"
-    extraFiles:
-      mountPath: /tmp/my-extra-files
-      configMaps:
-        - name: "my-backstage-extra-files-cm1"
-      secrets:
-        - name: "my-backstage-extra-files-secret1"
-          key: secret_file1.txt
-    extraEnvs:
-      envs:
-        - name: GITHUB_ORG
-          value: 'my-gh-org'
-        - name: MY_ENV_VAR_2
-          value: my-value-2
-      configMaps:
-        - name: my-env-cm-1
-        - name: my-env-cm-11
-          key: CM_ENV11
-      secrets:
-        - name: "my-backstage-backend-auth-secret"
-          key: BACKEND_SECRET
-        - name: my-gh-auth-secret
-
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -118,6 +78,8 @@ data:
     includes:
       - dynamic-plugins.default.yaml
     plugins:
+      - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-utils-dynamic
+        disabled: false
       - package: './dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic'
         disabled: false
         pluginConfig:
@@ -133,6 +95,7 @@ data:
                     timeout: { minutes: 3}
                     initialDelay: { seconds: 15}
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
+        disabled: false
         pluginConfig:
           # Reference documentation https://backstage.io/docs/features/techdocs/configuration
           # Note: After experimenting with basic setup, use CI/CD to generate docs
@@ -213,3 +176,43 @@ stringData:
     webhookSecret: someWebhookSecret
     privateKey: |
       SomeRsaPrivateKey
+
+---
+apiVersion: rhdh.redhat.com/v1alpha3
+kind: Backstage
+metadata:
+  name: bs-app-config
+spec:
+  database:
+    enableLocalDb: true
+  application:
+    replicas: 2
+    appConfig:
+      #mountPath:  /opt/app-root/src
+      configMaps:
+        - name: "my-backstage-config-backend-auth"
+        - name: "my-backstage-config-cm1"
+        - name: "my-backstage-config-cm2"
+          key: "app-config1-cm2.gh.yaml"
+    dynamicPluginsConfigMapName: "my-dynamic-plugins-config-cm"
+    extraFiles:
+      mountPath: /tmp/my-extra-files
+      configMaps:
+        - name: "my-backstage-extra-files-cm1"
+      secrets:
+        - name: "my-backstage-extra-files-secret1"
+          key: secret_file1.txt
+    extraEnvs:
+      envs:
+        - name: GITHUB_ORG
+          value: 'my-gh-org'
+        - name: MY_ENV_VAR_2
+          value: my-value-2
+      configMaps:
+        - name: my-env-cm-1
+        - name: my-env-cm-11
+          key: CM_ENV11
+      secrets:
+        - name: "my-backstage-backend-auth-secret"
+          key: BACKEND_SECRET
+        - name: my-gh-auth-secret


### PR DESCRIPTION
## Description
Some Technical Preview plugins are no longer enabled by default in RHDH 1.3+, and need to be explicitly enabled.

Ref: https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.3/html/release_notes/breaking-changes

## Which issue(s) does this PR fix or relate to

```
[...]
  [FAILED] Timed out after 300.054s.                                                                                                                                                           
  The function passed to Eventually failed at /home/asoro/work/projects/backstage/janus-idp/operator/tests/helper/helper_backstage.go:176 with:                                                
  context: /api/dynamic-plugins-info/loaded-plugins                                                                                                                                            
  Expected                                                                                                                                                                                     
      <string>: [{"name":"backstage-plugin-catalog-backend-module-github-dynamic","version":"0.6.5","platform":"node","role":"backend-plugin-module"},{"name":"backstage-plugin-catalog-backend
-module-gitlab-dynamic","version":"0.3.21","platform":"node","role":"backend-plugin-module"},{"name":"backstage-plugin-techdocs","version":"1.10.7","role":"frontend-plugin","platform":"web"},
{"name":"backstage-plugin-techdocs-backend-dynamic","version":"1.10.9","platform":"node","role":"backend-plugin"},{"name":"@janus-idp/backstage-plugin-analytics-provider-segment","version":"1
.7.2","role":"frontend-plugin","platform":"web"},{"name":"@janus-idp/backstage-scaffolder-backend-module-quay-dynamic","version":"1.7.1","platform":"node","role":"backend-plugin-module"},{"na
me":"@janus-idp/backstage-scaffolder-backend-module-regex-dynamic","version":"1.7.1","platform":"node","role":"backend-plugin-module"}]                                                        
  to contain substring                                                                                                                                                                         
      <string>: roadiehq-scaffolder-backend-module-utils-dynamic                                                                                                                               
  In [It] at: /home/asoro/work/projects/backstage/janus-idp/operator/tests/e2e/e2e_test.go:389 @ 10/16/24 11:33:35.093                                                                         
SSS•S•••

Summarizing 1 Failure:
  [FAIL] Backstage Operator E2E Examples CRs when applying RHDH CR with app-configs, dynamic plugins, extra files and extra-envs (examples/rhdh-cr-with-app-configs.yaml) [It] should handle CR as expected
  /home/asoro/work/projects/backstage/janus-idp/operator/tests/e2e/e2e_test.go:389Ran 5 of 9 Specs in 838.065 seconds
FAIL! -- 4 Passed | 1 Failed | 0 Pending | 4 Skipped
--- FAIL: TestE2E (838.07s)
FAILGinkgo ran 1 suite in 14m0.415770524sTest Suite Failed
make: *** [Makefile:427: test-e2e] Error 1
```

- Fixes https://issues.redhat.com/browse/RHIDP-4499

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer

`make test-e2e` against an OpenShift cluster should pass successfully:

```
$ make test-e2e

[...]                                                                                                                                                                                            
Ran 8 of 9 Specs in 659.714 seconds                                                                                                                                                            
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 1 Skipped                                                                                                                                        
PASS                                                                                                                                                                                           
Ginkgo ran 1 suite in 11m2.407803684s                                                                                                                                                          
Test Suite Passed 
```