### PR TITLE
Make the CI builds install script able to detect and work against clusters with hosted control planes

### DIFF
--- a/.rhdh/docs/installing-ci-builds.adoc
+++ b/.rhdh/docs/installing-ci-builds.adoc
@@ -2,8 +2,12 @@
 
 *Prerequisites*
 
-* You are logged in as an administrator on the OpenShift web console.
-* You have configured the appropriate roles and permissions within your project to create an application. See the link:https://docs.openshift.com/container-platform/4.17/applications/index.html[Red Hat OpenShift documentation on Building applications] for more details.
+* `oc`. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-installing-cli_cli-developer-commands[Installing the OpenShift CLI].
+* You are logged in as an administrator using `oc login`. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-logging-in_cli-developer-commands[Logging in to the OpenShift CLI] or link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-logging-in-web_cli-developer-commands[Logging in to the OpenShift CLI using a web browser].
+* `skopeo`. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
+* `opm`. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/opm-cli[opm CLI].
+* `podman`. See link:https://podman.io/docs/installation[Podman Installation Instructions].
+* `sed`. See link:https://www.gnu.org/software/sed/[GNU sed].
 
 *Procedure*
 

--- a/.rhdh/docs/installing-ci-builds.adoc
+++ b/.rhdh/docs/installing-ci-builds.adoc
@@ -1,15 +1,13 @@
 == Installing CI builds of Red Hat Developer Hub
 
-WARNING: The procedure below will not work properly on OpenShift clusters with hosted control planes, like link:https://hypershift-docs.netlify.app/[HyperShift] or link:https://www.redhat.com/en/blog/red-hat-openshift-service-aws-hosted-control-planes-now-available[ROSA with hosted control planes]. This is due to a limitation preventing link:https://docs.openshift.com/container-platform/4.14/rest_api/operator_apis/imagecontentsourcepolicy-operator-openshift-io-v1alpha1.html[`ImageContentSourcePolicy`] resources from being propagated to the cluster nodes. There is currently no workaround for these clusters.
-
 *Prerequisites*
 
 * You are logged in as an administrator on the OpenShift web console.
-* You have configured the appropriate roles and permissions within your project to create an application. See the link:https://docs.openshift.com/container-platform/4.14/applications/index.html[Red Hat OpenShift documentation on Building applications] for more details.
+* You have configured the appropriate roles and permissions within your project to create an application. See the link:https://docs.openshift.com/container-platform/4.17/applications/index.html[Red Hat OpenShift documentation on Building applications] for more details.
 
 *Procedure*
 
-. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator CatalogSource in your cluster. By default, it installs the Release Candidate or GA version (from the `1.yy.x` branch), but the `--next` option allows to install the current development build (from the `main` branch). For example:
+. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator CatalogSource in your cluster. By default, it installs the Release Candidate or GA version (from the `release-1.yy` branch), but the `--next` option allows to install the current development build (from the `main` branch). For example:
 +
 [source,console]
 ----
@@ -17,10 +15,10 @@ cd /tmp
 curl -sSLO https://raw.githubusercontent.com/redhat-developer/rhdh-operator/main/.rhdh/scripts/install-rhdh-catalog-source.sh
 chmod +x install-rhdh-catalog-source.sh
 
-# install catalog source and operator subscription, for the latest stable RC or GA from 1.yy.x branch
+# install catalog source and operator subscription, for the latest downstream stable, RC or GA build from the release-1.yy branch
 ./install-rhdh-catalog-source.sh --latest --install-operator rhdh  
 
-# OR, install catalog source and operator subscription, for the next CI build from main branch
+# OR, install catalog source and operator subscription, for the next donwstream CI build from the main branch
 ./install-rhdh-catalog-source.sh --next --install-operator rhdh  
 ----
 

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -251,7 +251,8 @@ function install_hosted_control_plane_cluster() {
     echo "[DEBUG] $originalBundleImg => $bundleImg" >&2
     if podman pull "$bundleImg" >&2; then
       mkdir -p "bundles/$digest" >&2
-      containerId=$(podman create "$bundleImg")
+      # --entrypoint is needed on some older versions of Podman, but work with
+      containerId=$(podman create --entrypoint='/bin/sh' "$bundleImg" || exit 1)
       podman cp $containerId:/metadata "./bundles/${digest}/metadata" >&2
       podman cp $containerId:/manifests "./bundles/${digest}/manifests" >&2
       podman rm -f $containerId >&2

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -128,80 +128,85 @@ function install_regular_cluster() {
   # TODO https://issues.redhat.com/browse/RHIDP-4188 if we onboard 1.3 to Konflux, use IDMS for latest too
   if [[ "$IIB_IMAGE" == *"next"* ]]; then
     echo "[INFO] Adding ImageDigestMirrorSet to resolve unreleased images on registry.redhat.io from quay.io" >&2
-    echo "apiVersion: config.openshift.io/v1
-  kind: ImageDigestMirrorSet
-  metadata:
-    name: ${ICSP_URL_PRE//./-}
-  spec:
-    imageDigestMirrors:
-    - source: registry.redhat.io/rhdh/rhdh-hub-rhel9
-      mirrors:
-        - ${ICSP_URL}rhdh-hub-rhel9
-    - source: registry.redhat.io/rhdh/rhdh-rhel9-operator
-      mirrors:
-        - ${ICSP_URL}rhdh-rhel9-operator
+    echo "---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: ${ICSP_URL_PRE//./-}
+spec:
+  imageDigestMirrors:
+  - source: registry.redhat.io/rhdh/rhdh-hub-rhel9
+    mirrors:
+      - ${ICSP_URL}rhdh-hub-rhel9
+  - source: registry.redhat.io/rhdh/rhdh-rhel9-operator
+    mirrors:
+      - ${ICSP_URL}rhdh-rhel9-operator
+  - source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-operator-bundle
+    mirrors:
+      - ${ICSP_URL}rhdh-operator-bundle
   " > "$TMPDIR/ImageDigestMirrorSet_${ICSP_URL_PRE}.yml" && oc apply -f "$TMPDIR/ImageDigestMirrorSet_${ICSP_URL_PRE}.yml" >&2
   else
     echo "[INFO] Adding ImageContentSourcePolicy to resolve references to images not on quay.io as if from quay.io" >&2
     # echo "[DEBUG] ${ICSP_URL_PRE}, ${ICSP_URL_PRE//./-}, ${ICSP_URL}"
-    echo "apiVersion: operator.openshift.io/v1alpha1
-  kind: ImageContentSourcePolicy
-  metadata:
-    name: ${ICSP_URL_PRE//./-}
-  spec:
-    repositoryDigestMirrors:
-    ## 1. add mappings for Developer Hub bundle, operator, hub
-    - mirrors:
-      - ${ICSP_URL}rhdh-operator-bundle
-      source: registry.redhat.io/rhdh/rhdh-operator-bundle
-    - mirrors:
-      - ${ICSP_URL}rhdh-operator-bundle
-      source: registry.stage.redhat.io/rhdh/rhdh-operator-bundle
-    - mirrors:
-      - ${ICSP_URL}rhdh-operator-bundle
-      source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-operator-bundle
+    echo "---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: ${ICSP_URL_PRE//./-}
+spec:
+  repositoryDigestMirrors:
+  ## 1. add mappings for Developer Hub bundle, operator, hub
+  - mirrors:
+    - ${ICSP_URL}rhdh-operator-bundle
+    source: registry.redhat.io/rhdh/rhdh-operator-bundle
+  - mirrors:
+    - ${ICSP_URL}rhdh-operator-bundle
+    source: registry.stage.redhat.io/rhdh/rhdh-operator-bundle
+  - mirrors:
+    - ${ICSP_URL}rhdh-operator-bundle
+    source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-operator-bundle
 
-    - mirrors:
-      - ${ICSP_URL}rhdh-rhel9-operator
-      source: registry.redhat.io/rhdh/rhdh-rhel9-operator
-    - mirrors:
-      - ${ICSP_URL}rhdh-rhel9-operator
-      source: registry.stage.redhat.io/rhdh/rhdh-rhel9-operator
-    - mirrors:
-      - ${ICSP_URL}rhdh-rhel9-operator
-      source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator
+  - mirrors:
+    - ${ICSP_URL}rhdh-rhel9-operator
+    source: registry.redhat.io/rhdh/rhdh-rhel9-operator
+  - mirrors:
+    - ${ICSP_URL}rhdh-rhel9-operator
+    source: registry.stage.redhat.io/rhdh/rhdh-rhel9-operator
+  - mirrors:
+    - ${ICSP_URL}rhdh-rhel9-operator
+    source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator
 
-    - mirrors:
-      - ${ICSP_URL}rhdh-hub-rhel9
-      source: registry.redhat.io/rhdh/rhdh-hub-rhel9
-    - mirrors:
-      - ${ICSP_URL}rhdh-hub-rhel9
-      source: registry.stage.redhat.io/rhdh/rhdh-hub-rhel9
-    - mirrors:
-      - ${ICSP_URL}rhdh-hub-rhel9
-      source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-hub-rhel9
+  - mirrors:
+    - ${ICSP_URL}rhdh-hub-rhel9
+    source: registry.redhat.io/rhdh/rhdh-hub-rhel9
+  - mirrors:
+    - ${ICSP_URL}rhdh-hub-rhel9
+    source: registry.stage.redhat.io/rhdh/rhdh-hub-rhel9
+  - mirrors:
+    - ${ICSP_URL}rhdh-hub-rhel9
+    source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-hub-rhel9
 
-    ## 2. general repo mappings
-    - mirrors:
-      - ${ICSP_URL_PRE}
-      source: registry.redhat.io
-    - mirrors:
-      - ${ICSP_URL_PRE}
-      source: registry.stage.redhat.io
-    - mirrors:
-      - ${ICSP_URL_PRE}
-      source: registry-proxy.engineering.redhat.com
+  ## 2. general repo mappings
+  - mirrors:
+    - ${ICSP_URL_PRE}
+    source: registry.redhat.io
+  - mirrors:
+    - ${ICSP_URL_PRE}
+    source: registry.stage.redhat.io
+  - mirrors:
+    - ${ICSP_URL_PRE}
+    source: registry-proxy.engineering.redhat.com
 
-    ### now add mappings to resolve internal references
-    - mirrors:
-      - registry.redhat.io
-      source: registry.stage.redhat.io
-    - mirrors:
-      - registry.stage.redhat.io
-      source: registry-proxy.engineering.redhat.com
-    - mirrors:
-      - registry.redhat.io
-      source: registry-proxy.engineering.redhat.com
+  ### now add mappings to resolve internal references
+  - mirrors:
+    - registry.redhat.io
+    source: registry.stage.redhat.io
+  - mirrors:
+    - registry.stage.redhat.io
+    source: registry-proxy.engineering.redhat.com
+  - mirrors:
+    - registry.redhat.io
+    source: registry-proxy.engineering.redhat.com
   " > "$TMPDIR/ImageContentSourcePolicy_${ICSP_URL_PRE}.yml" && oc apply -f "$TMPDIR/ImageContentSourcePolicy_${ICSP_URL_PRE}.yml" >&2
   fi
 

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -106,90 +106,6 @@ TMPDIR=$(mktemp -d)
 # shellcheck disable=SC2064
 trap "rm -fr $TMPDIR" EXIT
 
-ICSP_URL="quay.io/rhdh/"
-ICSP_URL_PRE=${ICSP_URL%%/*}
-
-# for 1.4+, use IDMS instead of ICSP
-# TODO https://issues.redhat.com/browse/RHIDP-4188 if we onboard 1.3 to Konflux, use IDMS for latest too
-if [[ "$IIB_IMAGE" == *"next"* ]]; then
-  echo "[INFO] Adding ImageDigestMirrorSet to resolve unreleased images on registry.redhat.io from quay.io"
-  echo "apiVersion: config.openshift.io/v1
-kind: ImageDigestMirrorSet
-metadata:
-  name: ${ICSP_URL_PRE//./-}
-spec:
-  imageDigestMirrors:
-  - source: registry.redhat.io/rhdh/rhdh-hub-rhel9
-    mirrors:
-      - ${ICSP_URL}rhdh-hub-rhel9
-  - source: registry.redhat.io/rhdh/rhdh-rhel9-operator
-    mirrors: 
-      - ${ICSP_URL}rhdh-rhel9-operator
-" > "$TMPDIR/ImageDigestMirrorSet_${ICSP_URL_PRE}.yml" && oc apply -f "$TMPDIR/ImageDigestMirrorSet_${ICSP_URL_PRE}.yml"
-else
-  echo "[INFO] Adding ImageContentSourcePolicy to resolve references to images not on quay.io as if from quay.io"
-  # echo "[DEBUG] ${ICSP_URL_PRE}, ${ICSP_URL_PRE//./-}, ${ICSP_URL}"
-  echo "apiVersion: operator.openshift.io/v1alpha1
-kind: ImageContentSourcePolicy
-metadata:
-  name: ${ICSP_URL_PRE//./-}
-spec:
-  repositoryDigestMirrors:
-  ## 1. add mappings for Developer Hub bundle, operator, hub
-  - mirrors:
-    - ${ICSP_URL}rhdh-operator-bundle
-    source: registry.redhat.io/rhdh/rhdh-operator-bundle
-  - mirrors:
-    - ${ICSP_URL}rhdh-operator-bundle
-    source: registry.stage.redhat.io/rhdh/rhdh-operator-bundle
-  - mirrors:
-    - ${ICSP_URL}rhdh-operator-bundle
-    source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-operator-bundle
-
-  - mirrors:
-    - ${ICSP_URL}rhdh-rhel9-operator
-    source: registry.redhat.io/rhdh/rhdh-rhel9-operator
-  - mirrors:
-    - ${ICSP_URL}rhdh-rhel9-operator
-    source: registry.stage.redhat.io/rhdh/rhdh-rhel9-operator
-  - mirrors:
-    - ${ICSP_URL}rhdh-rhel9-operator
-    source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator
-
-  - mirrors:
-    - ${ICSP_URL}rhdh-hub-rhel9
-    source: registry.redhat.io/rhdh/rhdh-hub-rhel9
-  - mirrors:
-    - ${ICSP_URL}rhdh-hub-rhel9
-    source: registry.stage.redhat.io/rhdh/rhdh-hub-rhel9
-  - mirrors:
-    - ${ICSP_URL}rhdh-hub-rhel9
-    source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-hub-rhel9
-
-  ## 2. general repo mappings
-  - mirrors:
-    - ${ICSP_URL_PRE}
-    source: registry.redhat.io
-  - mirrors:
-    - ${ICSP_URL_PRE}
-    source: registry.stage.redhat.io
-  - mirrors:
-    - ${ICSP_URL_PRE}
-    source: registry-proxy.engineering.redhat.com
-
-  ### now add mappings to resolve internal references
-  - mirrors:
-    - registry.redhat.io
-    source: registry.stage.redhat.io
-  - mirrors:
-    - registry.stage.redhat.io
-    source: registry-proxy.engineering.redhat.com
-  - mirrors:
-    - registry.redhat.io
-    source: registry-proxy.engineering.redhat.com
-" > "$TMPDIR/ImageContentSourcePolicy_${ICSP_URL_PRE}.yml" && oc apply -f "$TMPDIR/ImageContentSourcePolicy_${ICSP_URL_PRE}.yml"
-fi
-
 CATALOGSOURCE_NAME="${TO_INSTALL}-${OLM_CHANNEL}"
 DISPLAY_NAME_SUFFIX="${TO_INSTALL}"
 
@@ -202,6 +118,192 @@ if [ -z "$TO_INSTALL" ]; then
   CATALOGSOURCE_NAME="rhdh-iib-${IIB_NAME}-${OLM_CHANNEL}"
   DISPLAY_NAME_SUFFIX="${IIB_NAME}"
 fi
+
+function install_regular_cluster() {
+  # A regular cluster should support ImageContentSourcePolicy/ImageDigestMirrorSet resources
+  ICSP_URL="quay.io/rhdh/"
+  ICSP_URL_PRE=${ICSP_URL%%/*}
+
+  # for 1.4+, use IDMS instead of ICSP
+  # TODO https://issues.redhat.com/browse/RHIDP-4188 if we onboard 1.3 to Konflux, use IDMS for latest too
+  if [[ "$IIB_IMAGE" == *"next"* ]]; then
+    echo "[INFO] Adding ImageDigestMirrorSet to resolve unreleased images on registry.redhat.io from quay.io" >&2
+    echo "apiVersion: config.openshift.io/v1
+  kind: ImageDigestMirrorSet
+  metadata:
+    name: ${ICSP_URL_PRE//./-}
+  spec:
+    imageDigestMirrors:
+    - source: registry.redhat.io/rhdh/rhdh-hub-rhel9
+      mirrors:
+        - ${ICSP_URL}rhdh-hub-rhel9
+    - source: registry.redhat.io/rhdh/rhdh-rhel9-operator
+      mirrors:
+        - ${ICSP_URL}rhdh-rhel9-operator
+  " > "$TMPDIR/ImageDigestMirrorSet_${ICSP_URL_PRE}.yml" && oc apply -f "$TMPDIR/ImageDigestMirrorSet_${ICSP_URL_PRE}.yml" >&2
+  else
+    echo "[INFO] Adding ImageContentSourcePolicy to resolve references to images not on quay.io as if from quay.io" >&2
+    # echo "[DEBUG] ${ICSP_URL_PRE}, ${ICSP_URL_PRE//./-}, ${ICSP_URL}"
+    echo "apiVersion: operator.openshift.io/v1alpha1
+  kind: ImageContentSourcePolicy
+  metadata:
+    name: ${ICSP_URL_PRE//./-}
+  spec:
+    repositoryDigestMirrors:
+    ## 1. add mappings for Developer Hub bundle, operator, hub
+    - mirrors:
+      - ${ICSP_URL}rhdh-operator-bundle
+      source: registry.redhat.io/rhdh/rhdh-operator-bundle
+    - mirrors:
+      - ${ICSP_URL}rhdh-operator-bundle
+      source: registry.stage.redhat.io/rhdh/rhdh-operator-bundle
+    - mirrors:
+      - ${ICSP_URL}rhdh-operator-bundle
+      source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-operator-bundle
+
+    - mirrors:
+      - ${ICSP_URL}rhdh-rhel9-operator
+      source: registry.redhat.io/rhdh/rhdh-rhel9-operator
+    - mirrors:
+      - ${ICSP_URL}rhdh-rhel9-operator
+      source: registry.stage.redhat.io/rhdh/rhdh-rhel9-operator
+    - mirrors:
+      - ${ICSP_URL}rhdh-rhel9-operator
+      source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator
+
+    - mirrors:
+      - ${ICSP_URL}rhdh-hub-rhel9
+      source: registry.redhat.io/rhdh/rhdh-hub-rhel9
+    - mirrors:
+      - ${ICSP_URL}rhdh-hub-rhel9
+      source: registry.stage.redhat.io/rhdh/rhdh-hub-rhel9
+    - mirrors:
+      - ${ICSP_URL}rhdh-hub-rhel9
+      source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-hub-rhel9
+
+    ## 2. general repo mappings
+    - mirrors:
+      - ${ICSP_URL_PRE}
+      source: registry.redhat.io
+    - mirrors:
+      - ${ICSP_URL_PRE}
+      source: registry.stage.redhat.io
+    - mirrors:
+      - ${ICSP_URL_PRE}
+      source: registry-proxy.engineering.redhat.com
+
+    ### now add mappings to resolve internal references
+    - mirrors:
+      - registry.redhat.io
+      source: registry.stage.redhat.io
+    - mirrors:
+      - registry.stage.redhat.io
+      source: registry-proxy.engineering.redhat.com
+    - mirrors:
+      - registry.redhat.io
+      source: registry-proxy.engineering.redhat.com
+  " > "$TMPDIR/ImageContentSourcePolicy_${ICSP_URL_PRE}.yml" && oc apply -f "$TMPDIR/ImageContentSourcePolicy_${ICSP_URL_PRE}.yml" >&2
+  fi
+
+  printf "%s" "${IIB_IMAGE}"
+}
+
+function install_hosted_control_plane_cluster() {
+  # Clusters with an hosted control plane do not propagate ImageContentSourcePolicy/ImageDigestMirrorSet resources
+  # to the underlying nodes, causing an issue mirroring internal images effectively.
+  oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge >&2
+  my_registry=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
+  podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false $my_registry >&2
+  if oc -n openshift-marketplace get secret internal-reg-auth-for-rhdh > /dev/null; then
+    oc -n openshift-marketplace delete secret internal-reg-auth-for-rhdh >&2
+  fi
+  oc -n openshift-marketplace create secret docker-registry internal-reg-auth-for-rhdh \
+    --docker-server=${my_registry} \
+    --docker-username=$(oc whoami) \
+    --docker-password=$(oc whoami -t) \
+    --docker-email="admin@internal-registry.example.com" >&2
+  oc registry login --registry="$my_registry" --auth-basic="$(oc whoami):$(oc whoami -t)" >&2
+  for ns in rhdh-operator rhdh; do
+    # To be able to push images under this scope in the internal image registry
+    if ! oc get namespace "$ns" > /dev/null; then
+      oc create namespace "$ns" >&2
+    fi
+    oc adm policy add-cluster-role-to-user system:image-signer system:serviceaccount:${ns}:default >&2 || true
+  done
+  oc policy add-role-to-user system:image-puller system:serviceaccount:openshift-marketplace:default -n openshift-marketplace >&2 || true
+  oc policy add-role-to-user system:image-puller system:serviceaccount:rhdh-operator:default -n rhdh-operator >&2 || true
+
+  echo ">>> WORKING DIR: $TMPDIR <<<" >&2
+  mkdir -p "${TMPDIR}/rhdh/rhdh" >&2
+  opm render "$UPSTREAM_IIB" --output=yaml > "${TMPDIR}/rhdh/rhdh/render.yaml"
+  pushd "${TMPDIR}" >&2
+  for bundleImg in $(cat "${TMPDIR}/rhdh/rhdh/render.yaml" | grep -E '^image: .*operator-bundle' | awk '{print $2}' | uniq); do
+    originalBundleImg="$bundleImg"
+    digest="${originalBundleImg##*@sha256:}"
+    bundleImg="${bundleImg/registry.stage.redhat.io/quay.io}"
+    bundleImg="${bundleImg/registry.redhat.io/quay.io}"
+    bundleImg="${bundleImg/registry-proxy.engineering.redhat.com\/rh-osbs\/rhdh-/quay.io\/rhdh\/}"
+    echo "[DEBUG] $originalBundleImg => $bundleImg" >&2
+    if podman pull "$bundleImg" >&2; then
+      mkdir -p "bundles/$digest" >&2
+      containerId=$(podman create "$bundleImg")
+      podman cp $containerId:/metadata "./bundles/${digest}/metadata" >&2
+      podman cp $containerId:/manifests "./bundles/${digest}/manifests" >&2
+      podman rm -f $containerId >&2
+
+      # Replace the occurrences in the .csv.yaml or .clusterserviceversion.yaml files
+      for file in "./bundles/${digest}/manifests"/*; do
+        if [ -f "$file" ]; then
+          sed -i 's#registry.redhat.io/rhdh#quay.io/rhdh#g' "$file" >&2
+          sed -i 's#registry.stage.redhat.io/rhdh#quay.io/rhdh#g' "$file" >&2
+          sed -i 's#registry-proxy.engineering.redhat.com/rh-osbs/rhdh-#quay.io/rhdh/#g' "$file" >&2
+        fi
+      done
+
+      cat <<EOF > "./bundles/${digest}/bundle.Dockerfile"
+FROM scratch
+COPY ./manifests /manifests/
+COPY ./metadata /metadata/
+EOF
+      pushd "./bundles/${digest}" >&2
+      newBundleImage="${my_registry}/rhdh/rhdh-operator-bundle:${digest}"
+      podman image build -f bundle.Dockerfile -t "${newBundleImage}" . >&2
+      podman image push "${newBundleImage}" >&2
+      popd >&2
+
+      sed -i "s#${originalBundleImg}#${newBundleImage}#g" "${TMPDIR}/rhdh/rhdh/render.yaml" >&2
+    fi
+  done
+
+  local newIndex="${UPSTREAM_IIB/quay.io/"${my_registry}"}"
+
+  opm generate dockerfile rhdh/rhdh >&2
+  podman image build -t "${newIndex}" -f "./rhdh/rhdh.Dockerfile" --no-cache rhdh >&2
+  podman image push "${newIndex}" >&2
+
+  printf "%s" "${newIndex}"
+}
+
+# Defaulting to the hosted control plane behavior which has more chances to work
+CONTROL_PLANE_TECH=$(oc get infrastructure cluster -o jsonpath='{.status.controlPlaneTopology}' || \
+  (echo '[WARN] Could not determine the cluster type => defaulting to the hosted control plane behavior' >&2 && echo 'External'))
+IS_HOSTED_CONTROL_PLANE="false"
+if [[ "${CONTROL_PLANE_TECH}" == "External" ]]; then
+  # 'External' indicates that the control plane is hosted externally to the cluster
+  # and that its components are not visible within the cluster.
+  IS_HOSTED_CONTROL_PLANE="true"
+fi
+
+newIIBImage=${IIB_IMAGE}
+if [[ "${IS_HOSTED_CONTROL_PLANE}" = "true" ]]; then
+  echo "[INFO] Detected a cluster with a hosted control plane"
+  newIIBImage=$(install_hosted_control_plane_cluster)
+else
+  newIIBImage=$(install_regular_cluster)
+fi
+
+echo "[DEBUG] newIIBImage=${newIIBImage}"
+
 echo "apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -209,7 +311,9 @@ metadata:
   namespace: ${NAMESPACE_CATALOGSOURCE}
 spec:
   sourceType: grpc
-  image: ${IIB_IMAGE}
+  image: ${newIIBImage}
+  secrets:
+  - "internal-reg-auth-for-rhdh"
   publisher: IIB testing ${DISPLAY_NAME_SUFFIX}
   displayName: IIB testing catalog ${DISPLAY_NAME_SUFFIX}
 " > "$TMPDIR"/CatalogSource.yml && oc apply -f "$TMPDIR"/CatalogSource.yml
@@ -242,11 +346,12 @@ spec:
   sourceNamespace: ${NAMESPACE_CATALOGSOURCE}
 " > "$TMPDIR"/Subscription.yml && oc apply -f "$TMPDIR"/Subscription.yml
 
-CLUSTER_ROUTER_BASE=$(oc get route console -n openshift-console -o=jsonpath='{.spec.host}' | sed 's/^[^.]*\.//')
+OCP_CONSOLE_ROUTE_HOST=$(oc get route console -n openshift-console -o=jsonpath='{.spec.host}')
+CLUSTER_ROUTER_BASE=$(oc get ingress.config.openshift.io/cluster '-o=jsonpath={.spec.domain}')
 echo "
 
 To install, go to:
-https://console-openshift-console.${CLUSTER_ROUTER_BASE}/catalog/ns/${NAMESPACE_SUBSCRIPTION}?catalogType=OperatorBackedService
+https://${OCP_CONSOLE_ROUTE_HOST}/catalog/ns/${NAMESPACE_SUBSCRIPTION}?catalogType=OperatorBackedService
 
 Or run this:
 

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -273,7 +273,7 @@ EOF
       pushd "./bundles/${digest}" >&2
       newBundleImage="${my_registry}/rhdh/rhdh-operator-bundle:${digest}"
       podman image build -f bundle.Dockerfile -t "${newBundleImage}" . >&2
-      podman image push "${newBundleImage}" >&2
+      podman image push "${newBundleImage}" --tls-verify=false >&2
       popd >&2
 
       sed -i "s#${originalBundleImg}#${newBundleImage}#g" "${TMPDIR}/rhdh/rhdh/render.yaml" >&2
@@ -284,7 +284,7 @@ EOF
 
   opm generate dockerfile rhdh/rhdh >&2
   podman image build -t "${newIndex}" -f "./rhdh/rhdh.Dockerfile" --no-cache rhdh >&2
-  podman image push "${newIndex}" >&2
+  podman image push "${newIndex}" --tls-verify=false >&2
 
   printf "%s" "${newIndex}"
 }


### PR DESCRIPTION
## Description

This PR makes the `.rhdh/scripts/install-rhdh-catalog-source.sh` script detect whether the OCP cluster it is running against has a hosted control plane (HyperShift, ROSA, IBM Cloud, ...) and adapts its behavior accordingly.
In such a situation where the control plane is hosted, we cannot actually rely on the ImageContentSourcePolicy/ImageDigestMirrorSet, which will be created but won't be propagated to the cluster nodes.
As a workaround, this script rebuilds a new index by replacing all references to the internal registries with their equivalents on quay.io. It also does the same thing with the operator bundles, because the manifests in them might also contain references to internal registries. It pushes those new images into the internal cluster image registry.

#82 provided a similar attempt based on mirroring all images (airgap use case), but I think we still need to also rebuild the operator bundles because the manifests in them still contain references to internal registries. Also, I was surprised to see that updating the global secret on hosted control planes does not get propagated to the cluster nodes.

NOTE: We might be able to reuse that logic to make the airgap script work on such clusters as well. But this can be done in a follow-up step. [2]

[1] https://issues.redhat.com/browse/RHIDP-4415

## Which issue(s) does this PR fix or relate to

- Relates to https://issues.redhat.com/browse/RHIDP-3205
- Relates to https://issues.redhat.com/browse/RHIDP-2919

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
1. [Skip if you already have a cluster] Start an OCP cluster with a hosted control plane, e.g. with `rosa create 4.16 2h` on ClusterBot, or an OCP cluster on IBM Cloud
2. `oc login` against your OCP cluster
3. Run the install script: `.rhdh/scripts/install-rhdh-catalog-source.sh --[next|latest] --install-operator rhdh`.
The CatalogSource and operator should be installed and running, which was not the case previously.

![Screenshot from 2024-10-25 11-18-22](https://github.com/user-attachments/assets/be35abae-c72e-4241-950a-bc1f4e265ecb)

![image](https://github.com/user-attachments/assets/3fa2b493-d7d3-4dc5-8d36-ddd2022e690a)

4. Create a Backstage CR and make sure it runs

![image](https://github.com/user-attachments/assets/84945e61-03b6-4a3d-9e28-9a7febed3b34)

NOTES:
- The script should behave as previously on regular OpenShift clusters, i.e. by relying on `ImageContentSourcePolicy` / `ImageDigestMirrorSet` resources to mirror internal images.
- ~This will not work if routes are exposed with untrusted certificates (case of clusters created via `launch 4.x`). There is a TLS verification failure when trying to pull from the internal image registry, and I couldn't find a way to make the cluster accept/ignore this certificate (I guess because the control plane is hosted).~ (Fixed with [`38ba118` (#369)](https://github.com/redhat-developer/rhdh-operator/pull/369/commits/38ba118d19aa4a8b8963c77dfd58581218846eff))

/cc @nickboldt @Fortune-Ndlovu @Omar-AlJaljuli