### PR TITLE
chore(update):  Updating Channel does not trigger an Operator Update

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -355,4 +355,4 @@ spec:
     name: Red Hat Inc.
     url: https://www.redhat.com/
   version: 1.2.5
-  replaces: rhdh-operator.v1.1.1
+  replaces: rhdh-operator.v1.2.4


### PR DESCRIPTION
Ensure the replaces field is correctly pointing to the previous version.

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
