### PR TITLE
chore(update): Updating Channel does not trigger an Operator Update

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -357,4 +357,4 @@ spec:
     name: Red Hat Inc.
     url: https://www.redhat.com/
   version: 1.3.2
-  replaces: rhdh-operator.v1.1.1
+  replaces: rhdh-operator.v1.2.4

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-10-10T15:58:03Z"
+    createdAt: "2024-11-17T23:30:16Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    skipRange: '>=0.0.1 <0.3.2'
+    skipRange: '>=0.0.1 <0.3.1'
   name: backstage-operator.v0.3.2
   namespace: placeholder
 spec:
@@ -214,7 +214,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/rhdh/rhdh-hub-rhel9:next
-                image: quay.io/rhdh-community/operator:0.3.1
+                image: quay.io/rhdh-community/operator:0.3.2
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.3.1
+  newTag: 0.3.2
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Set the replaces field to the most recent 1.2.x version

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
