### PR TITLE
[RHIDP-4934] Fix issue preventing the CI install script from being used in restricted systems where Podman would not work

### DIFF
--- a/.rhdh/docs/installing-ci-builds.adoc
+++ b/.rhdh/docs/installing-ci-builds.adoc
@@ -1,13 +1,13 @@
-== Installing CI builds of Red Hat Developer Hub
+== Installing CI builds of Red Hat Developer Hub on OpenShift
 
 *Prerequisites*
 
 * `oc`. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-installing-cli_cli-developer-commands[Installing the OpenShift CLI].
 * You are logged in as an administrator using `oc login`. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-logging-in_cli-developer-commands[Logging in to the OpenShift CLI] or link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-logging-in-web_cli-developer-commands[Logging in to the OpenShift CLI using a web browser].
-* `skopeo`. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
 * `opm`. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/opm-cli[opm CLI].
-* `podman`. See link:https://podman.io/docs/installation[Podman Installation Instructions].
 * `sed`. See link:https://www.gnu.org/software/sed/[GNU sed].
+* `skopeo`. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
+* `umoci` (used if the script detects that the cluster has a hosted control plane). See link:https://github.com/opencontainers/umoci#install[Install].
 
 *Procedure*
 

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -4,7 +4,7 @@
 #
 # Requires: oc, jq
 
-set -e
+set -euo pipefail
 
 RED='\033[0;31m'
 NC='\033[0m'


### PR DESCRIPTION
## Description
In Prow CI containers, it appears that Podman could not be used due to a restricted environment.
The error below was returned:
```
[...]
 [DEBUG] registry.redhat.io/rhdh/rhdh-operator-bundle@sha256:2abaeacfa8fd744579e44e4b320086a8678094dd92eb24825c05f43617384529 => quay.io/rhdh/rhdh-operator-bundle@sha256:2abaeacfa8fd744579e44e4b320086a8678094dd92eb24825c05f43617384529
time="2024-11-14T08:04:54Z" level=warning msg="\"/\" is not a shared mount, this could cause issues or missing mounts with rootless containers"
cannot clone: Operation not permitted
Error: cannot re-exec process
[...]
```

This PR removes the need for Podman to build and push the images. Instead, it now leverages both umoci [1] and Skopeo to manipulate the images, rebuild and repush them in the internal cluster registry.

[1] https://github.com/opencontainers/umoci

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-4934

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer

- OCP Cluster with a hosted control plane, like a ROSA or IBM Cloud cluster
- Install umoci and Skopeo
- Run the install script against this cluster, e.g.:
```shell
.rhdh/scripts/install-rhdh-catalog-source.sh --next --install-operator rhdh
```

=> The RHDH Operator should be deployed and running in the cluster after a few minutes.