### PR TITLE
feat: add support for exposing OpenTelemetry metrics port

### DIFF
--- a/bundle/backstage.io/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/backstage.io/manifests/backstage-default-config_v1_configmap.yaml
@@ -199,6 +199,10 @@ data:
         - name: http-backend
           port: 80
           targetPort: backend
+        - name: http-metrics
+          protocol: TCP
+          port: 9464
+          targetPort: 9464
 kind: ConfigMap
 metadata:
   name: backstage-default-config

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
-    createdAt: "2024-11-15T19:48:11Z"
+    createdAt: "2024-11-20T18:31:29Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -336,6 +336,10 @@ data:
         - name: http-backend
           port: 80
           targetPort: backend
+        - name: http-metrics
+          protocol: TCP
+          port: 9464
+          targetPort: 9464
 kind: ConfigMap
 metadata:
   name: rhdh-default-config

--- a/config/profile/backstage.io/default-config/service.yaml
+++ b/config/profile/backstage.io/default-config/service.yaml
@@ -10,3 +10,7 @@ spec:
     - name: http-backend
       port: 80
       targetPort: backend
+    - name: http-metrics
+      protocol: TCP
+      port: 9464
+      targetPort: 9464

--- a/config/profile/rhdh/default-config/service.yaml
+++ b/config/profile/rhdh/default-config/service.yaml
@@ -10,3 +10,7 @@ spec:
     - name: http-backend
       port: 80
       targetPort: backend
+    - name: http-metrics
+      protocol: TCP
+      port: 9464
+      targetPort: 9464


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Exposes an extra port (9464) in the backstage service for the Backstage metrics

## Which issue(s) does this PR fix or relate to

[RHIDP-5005](https://issues.redhat.com/browse/RHIDP-5005)

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
Install the ServiceMonitor manually, and Backstage metrics will appear under `Observe` > `Metrics`
```
# make sure to update CR_NAME value accordingly
$ CR_NAME=bs1
$ MY_PROJECT=rhdh-test
$ cat <<EOF > /tmp/${CR_NAME}.ServiceMonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: ${CR_NAME}
  namespace: ${MY_PROJECT}
  labels:
    app.kubernetes.io/instance: ${CR_NAME}
    app.kubernetes.io/name: backstage
spec:
  namespaceSelector:
    matchNames:
      - ${MY_PROJECT}
  selector:
    matchLabels:
      app.kubernetes.io/instance: ${CR_NAME}
      app.kubernetes.io/name: backstage
  endpoints:
    - port: http-metrics
      path: /metrics
EOF
$ oc apply -f /tmp/${CR_NAME}.ServiceMonitor.yaml
```