### PR TITLE
fix(release-1.3): Fix the E2E tests on `release-1.3`

### DIFF
--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -199,7 +199,7 @@ data:
                 - ./install-dynamic-plugins.sh
                 - /dynamic-plugins-root
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/rhdh/rhdh-hub-rhel9:next
+              image: quay.io/rhdh/rhdh-hub-rhel9:1.3
               imagePullPolicy: IfNotPresent
               securityContext:
                 runAsNonRoot: true
@@ -236,7 +236,7 @@ data:
           containers:
             - name: backstage-backend
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/rhdh/rhdh-hub-rhel9:next
+              image: quay.io/rhdh/rhdh-hub-rhel9:1.3
               imagePullPolicy: IfNotPresent
               args:
                 - "--config"

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-11-25T17:32:33Z"
+    createdAt: "2024-11-26T08:07:46Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    skipRange: '>=0.0.1 <0.3.1'
+    skipRange: '>=0.0.1 <0.3.2'
   name: backstage-operator.v0.3.2
   namespace: placeholder
 spec:

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-10-10T15:58:03Z"
+    createdAt: "2024-11-25T09:48:20Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -213,8 +213,8 @@ spec:
                 - name: RELATED_IMAGE_postgresql
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
-                  value: quay.io/rhdh/rhdh-hub-rhel9:next
-                image: quay.io/rhdh-community/operator:0.3.1
+                  value: quay.io/rhdh/rhdh-hub-rhel9:1.3
+                image: quay.io/rhdh-community/operator:0.3.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -313,7 +313,7 @@ spec:
   relatedImages:
   - image: quay.io/fedora/postgresql-15:latest
     name: postgresql
-  - image: quay.io/rhdh/rhdh-hub-rhel9:next
+  - image: quay.io/rhdh/rhdh-hub-rhel9:1.3
     name: backstage
   replaces: backstage-operator.v0.2.0
   version: 0.3.2

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - ./install-dynamic-plugins.sh
             - /dynamic-plugins-root
           # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-          image: quay.io/rhdh/rhdh-hub-rhel9:next
+          image: quay.io/rhdh/rhdh-hub-rhel9:1.3
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
@@ -83,7 +83,7 @@ spec:
       containers:
         - name: backstage-backend
           # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-          image: quay.io/rhdh/rhdh-hub-rhel9:next
+          image: quay.io/rhdh/rhdh-hub-rhel9:1.3
           imagePullPolicy: IfNotPresent
           args:
             - "--config"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,19 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.3.1
+  newTag: 0.3.2
+
+patches:
+- patch: |-
+    - op: replace
+      path: "/spec/template/spec/containers/0/env/1"
+      value:
+        name: RELATED_IMAGE_backstage
+        value: "quay.io/rhdh/rhdh-hub-rhel9:1.3"
+  target:
+    kind: Deployment
+    name: controller-manager
+    namespace: system
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
@@ -5,8 +5,8 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     operatorframework.io/suggested-namespace: backstage-system
-    skipRange: '>=0.0.1 <0.3.1'
-  name: backstage-operator.v0.3.1
+    skipRange: '>=0.0.1 <0.3.2'
+  name: backstage-operator.v0.3.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Backstage Operator E2E", func() {
 						BodyMatcher: SatisfyAll(
 							ContainSubstring("@janus-idp/backstage-scaffolder-backend-module-quay-dynamic"),
 							ContainSubstring("@janus-idp/backstage-scaffolder-backend-module-regex-dynamic"),
-							ContainSubstring("roadiehq-scaffolder-backend-module-utils-dynamic"),
+							// ContainSubstring("roadiehq-scaffolder-backend-module-utils-dynamic"),
 							ContainSubstring("backstage-plugin-catalog-backend-module-github-dynamic"),
 							ContainSubstring("backstage-plugin-techdocs-backend-dynamic"),
 							ContainSubstring("backstage-plugin-catalog-backend-module-gitlab-dynamic")),


### PR DESCRIPTION
## Description
The nightly checks have been failing recently (especially the job against the `release-1.3` branch). See https://github.com/redhat-developer/rhdh-operator/actions/runs/12000574475/job/33449852746

It turns out that we are using the `next` RHDH tag, which now seems to require a new mandatory `auth.providers` field in the app-config (added recently in the `main` branches for both [Helm](https://github.com/redhat-developer/rhdh-chart/pull/46/files#diff-8060d9a38501197eddb026fced7fe56f104f4f5143210c6d47781b831a7097f4) and the [Operator](https://github.com/redhat-developer/rhdh-operator/pull/393/files#diff-4c1e3001a09525c00affd3f7eaf28970ecbe52bc189532ad34731b604cbd31f9)).

This PR makes sure to use the 1.3 RHDH tag in the release-1.3 branch by default.

With hindsight, I think that, going forward, it might make sense for release branches to not use the `next` or `latest` tags for the operand, as those might contain potential breaking changes.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-5045

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer

Run this against an OCP cluster.
On a vanilla K8s cluster, only the `test-e2e-upgrade` test will fail. `test-e2e` will pass on vanilla K8s because those tests do not check that the deployed instances are actually reachable (because of the lack of Ingress).

```
$ make test-e2e test-e2e-upgrade

[...]
Ran 5 of 6 Specs in 690.701 seconds                                                                                                                                                            
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 1 Skipped                                                                                                                                        
PASS                                                                                                                                                                                           
                                                                                                                                                                                               
Ginkgo ran 1 suite in 11m34.10414685s

[...]
Ran 1 of 6 Specs in 229.450 seconds                                                                                                                                                            
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 5 Skipped                                                                                                                                        
PASS                                                                                                                                                                                           
                                                                                                                                                                                               
Ginkgo ran 1 suite in 3m53.235129592s                                                                                                                                                          
Test Suite Passed
```
