### PR TITLE
ci: Make the nightly E2E tests more robust when testing the loaded plugins endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.36.0
 	github.com/openshift/api v0.0.0-20240419172957-f39cf2ef93fd
 	github.com/stretchr/testify v1.10.0
+	github.com/tidwall/gjson v1.18.0
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	k8s.io/api v0.31.3
 	k8s.io/apiextensions-apiserver v0.31.3
@@ -71,6 +72,8 @@ require (
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,13 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -163,7 +163,7 @@ subjects:
 `, ns),
 					}
 				},
-				expectedLogsMatcher: ContainSubstring(`workqueue_work_duration_seconds_count{name="backstage"}`),
+				expectedLogsMatcher: ContainSubstring(`workqueue_work_duration_seconds_count`),
 			},
 		} {
 			tt := tt


### PR DESCRIPTION
## Description

The E2E nightly jobs would fail because the list of dynamic plugins had changed in the `next` RHDH tag the operator uses by default.
To make things more stable (and because verifying the actual list of loaded plugins is outside of the operator scope), this PR just checks that the list fetched from the running app is a non-empty array. This is sufficient to make sure that the created application is up and running, from the operator perspective.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
`make test-e2e` should pass.
