### PR TITLE
ci: Include the 'release-1.4' branch in the E2E Nightly checks

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.3, 1.2.x ]
+        branch: [ main, release-1.4, release-1.3, 1.2.x ]
         test_upgrade: [ 'true', 'false' ]
         exclude:
           - branch: 1.2.x


### PR DESCRIPTION
## Description
This includes the 'release-1.4' branch in the E2E Nightly checks

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
