### PR TITLE
Fix missing `RELATED_IMAGE_*` env vars from the `rhdh` profile

### DIFF
--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -59,7 +59,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
-    skipRange: '>=1.0.0 <1.3.0'
+    skipRange: '>=1.0.0 <1.4.0'
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
-    createdAt: "2024-11-20T18:31:29Z"
+    createdAt: "2024-11-27T11:19:54Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed
@@ -234,6 +234,17 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
+                env:
+                - name: OPERATOR_NAME
+                  value: rhdh-operator
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: RELATED_IMAGE_postgresql
+                  value: quay.io/fedora/postgresql-15:latest
+                - name: RELATED_IMAGE_backstage
+                  value: quay.io/rhdh/rhdh-hub-rhel9:1.4
                 image: quay.io/rhdh-community/operator:0.4.0
                 livenessProbe:
                   httpGet:
@@ -347,5 +358,10 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
+  relatedImages:
+  - image: quay.io/fedora/postgresql-15:latest
+    name: postgresql
+  - image: quay.io/rhdh/rhdh-hub-rhel9:1.4
+    name: backstage
   replaces: rhdh-operator.v1.2.0
   version: 0.4.0

--- a/config/manifests/rhdh/bases/csv.yaml
+++ b/config/manifests/rhdh/bases/csv.yaml
@@ -27,7 +27,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
     support: Red Hat
-    skipRange: '>=1.0.0 <1.3.0'
+    skipRange: '>=1.0.0 <1.4.0'
   # name should fit the project name and version (i e backstage-operator.vX.Y.Z) , otherwise this CSV base will not be used
   name: backstage-operator.v0.4.0
 spec:

--- a/config/profile/rhdh/kustomization.yaml
+++ b/config/profile/rhdh/kustomization.yaml
@@ -138,6 +138,18 @@ images:
   newName: quay.io/rhdh-community/operator
   newTag: 0.4.0
 
+patches:
+- patch: |-
+    - op: replace
+      path: "/spec/template/spec/containers/0/env/3"
+      value:
+        name: RELATED_IMAGE_backstage
+        value: "quay.io/rhdh/rhdh-hub-rhel9:1.4"
+  target:
+    kind: Deployment
+    name: controller-manager
+    namespace: operator
+
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/config/profile/rhdh/manager.yaml
+++ b/config/profile/rhdh/manager.yaml
@@ -75,17 +75,17 @@ spec:
           - --metrics-bind-address=:8443
           - --metrics-secure=true
           - --leader-elect
-#        env:
-#          - name: OPERATOR_NAME
-#            value: rhdh-operator
-#          - name: POD_NAME
-#            valueFrom:
-#              fieldRef:
-#                fieldPath: metadata.name
-#          - name: RELATED_IMAGE_backstage
-#            value: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-hub-rhel9:1.3
-#          - name: RELATED_IMAGE_postgresql
-#            value: registry.redhat.io/rhel9/postgresql-15:latest
+        env:
+          - name: OPERATOR_NAME
+            value: rhdh-operator
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: RELATED_IMAGE_postgresql
+            value: quay.io/fedora/postgresql-15:latest
+          - name: RELATED_IMAGE_backstage
+            value: quay.io/rhdh/rhdh-hub-rhel9:next
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
## Description

Otherwise, we may end up with E2E tests failing, as fixed in #413 for 1.3

## Which issue(s) does this PR fix or relate to

- Related to https://issues.redhat.com/browse/RHIDP-5045
- Related to https://github.com/redhat-developer/rhdh-operator/pull/413

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
