### PR TITLE
Add missing `RELATED_IMAGE_*` env vars to the `rhdh` profile

### DIFF
--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
-    createdAt: "2024-11-26T21:42:17Z"
+    createdAt: "2024-11-27T12:15:30Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed
@@ -234,6 +234,17 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
+                env:
+                - name: OPERATOR_NAME
+                  value: rhdh-operator
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: RELATED_IMAGE_postgresql
+                  value: quay.io/fedora/postgresql-15:latest
+                - name: RELATED_IMAGE_backstage
+                  value: quay.io/rhdh/rhdh-hub-rhel9:next
                 image: quay.io/rhdh-community/operator:0.5.0
                 livenessProbe:
                   httpGet:
@@ -347,5 +358,10 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
+  relatedImages:
+  - image: quay.io/fedora/postgresql-15:latest
+    name: postgresql
+  - image: quay.io/rhdh/rhdh-hub-rhel9:next
+    name: backstage
   replaces: rhdh-operator.v1.2.0
   version: 0.5.0

--- a/config/profile/rhdh/manager.yaml
+++ b/config/profile/rhdh/manager.yaml
@@ -75,17 +75,17 @@ spec:
           - --metrics-bind-address=:8443
           - --metrics-secure=true
           - --leader-elect
-#        env:
-#          - name: OPERATOR_NAME
-#            value: rhdh-operator
-#          - name: POD_NAME
-#            valueFrom:
-#              fieldRef:
-#                fieldPath: metadata.name
-#          - name: RELATED_IMAGE_backstage
-#            value: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-hub-rhel9:1.3
-#          - name: RELATED_IMAGE_postgresql
-#            value: registry.redhat.io/rhel9/postgresql-15:latest
+        env:
+          - name: OPERATOR_NAME
+            value: rhdh-operator
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: RELATED_IMAGE_postgresql
+            value: quay.io/fedora/postgresql-15:latest
+          - name: RELATED_IMAGE_backstage
+            value: quay.io/rhdh/rhdh-hub-rhel9:next
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
## Description
See PR title.

## Which issue(s) does this PR fix or relate to

- Relates to https://issues.redhat.com/browse/RHIDP-2387
- Relates to https://github.com/redhat-developer/rhdh-operator/pull/450

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer

