### PR TITLE
chore(renovate): temporarily quiet immortal PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,7 @@
   "constraints": {
     "go": "1.21"
   },
+  "recreateWhen": "never",
   "packageRules": [
     {
       "description": "Do NOT generate PRs to pin or apply digests to dockerfiles",


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

Temporarily add config to prevent [immortal PRs ](https://docs.renovatebot.com/key-concepts/pull-requests/#how-to-fix-immortal-prs) from re-opening.  Needed to clean out older renovate PRs

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
