### PR TITLE
chore(renovate): fix some rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,21 @@
       "automerge": false
     },
     {
+      "description": "Do NOT generate PRs for minor dockerfile updates in 1.y ",
+      "enabled": false,
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "matchBaseBranches": [
+        "/^release-1\\.3/",
+        "/^1\\.2\\.x/"
+      ],      
+      "automerge": false
+    },  
+    {
       "description": "Do automerge patch updates to dockerfiles",
       "enabled": true,
       "matchDatasources": [
@@ -51,17 +66,16 @@
       "pinDigests": false
     },
     {
-      "description": "k8s go: patch updates only in 1.y (these branches use go < 1.22)",
+      "description": "k8s go: disable minor updates in 1.y (these branches use go < 1.22)",
       "enabled": false,
       "groupName": "k8s-go 1.y",
       "matchDatasources": [
         "go"
       ],
       "matchUpdateTypes": [
-        "patch",
-        "digest"
+         "minor"
       ],
-      "baseBranches": [
+      "matchBaseBranches": [
         "/^release-1\\.3/",
         "/^1\\.2\\.x/"
       ],
@@ -75,16 +89,16 @@
       ]
     },
     {
-      "description": "ginkgo: patch updates only in 1.y (disabled because Go 1.22+ is required since ginkgo 2.20.2)",
+      "description": "ginkgo: disable minor updates only in 1.y (disabled because Go 1.22+ is required since ginkgo 2.20.2)",
       "enabled": false,
       "groupName": "ginkgo 1.y",
       "matchDatasources": [
         "go"
       ],
       "matchUpdateTypes": [
-        "patch"
+        "minor"
       ],
-      "baseBranches": [
+      "matchBaseBranches": [
         "/^release-1\\.3/",
         "/^1\\.2\\.x/"
       ],
@@ -101,9 +115,9 @@
         "go"
       ],
       "matchUpdateTypes": [
-        "patch"
+        "minor"
       ],
-      "baseBranches": [
+      "matchBaseBranches": [
         "/^release-1\\..*/",
         "/^1\\.2\\.x/"
       ],


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
Some of the existing rules were disabling patch updates.  This allowed minor updates on Z stream branches which caused incorrect and (immortal) PRs to be created.   I also updated some of the `baseBranches` configs to use [matchBaseBranches](https://docs.renovatebot.com/configuration-options/#matchbasebranches) which is more applicable to package rules.  



## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

I tested similar renovate configs on my own repo.  I think these [PRs](https://github.com/kim-tsao/operator-renovate/pulls) are more inline with what we want.  Note, we don't seem to be getting image update PRs in the maintenance releases and I think it's because we're disabling digest pinning.  
