### PR TITLE
chore(renovate): Run `go mod tidy` after each Renovate update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,10 @@
   },
   "kustomize": {
     "enabled": false
-  },   
+  },
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "packageRules": [
     {
       "description": "Do NOT generate PRs to pin or apply digests to dockerfiles",


### PR DESCRIPTION
## Description

As the title suggests, this PR instructs Renovate to run `go mod tidy` after every dependency update, to make sure the `go.sum` file is consistent.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer

More details at https://docs.renovatebot.com/modules/manager/gomod/#post-update-options

/cc @kim-tsao 