### PR TITLE
chore(fixup):[release-1.3] update Configuring external PostgreSQL dat…

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -80,7 +80,7 @@ spec:
     * [Product Documentation](https://access.redhat.com/documentation/en-us/red_hat_developer_hub)
     * [Life Cycle](https://access.redhat.com/node/7025299)
     * [Support Policies](https://access.redhat.com/policy/developerhub-support-policy)
-    * [Configuring external PostgreSQL databases](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.3/html/administration_guide_for_red_hat_developer_hub/assembly-configuring-external-postgresql-databases#assembly-configuring-external-postgresql-databases)
+    * [Configuring external PostgreSQL databases](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.3/html/administration_guide_for_red_hat_developer_hub/index#assembly-configuring-external-postgresql-databases)
 
   displayName: Red Hat Developer Hub Operator
   icon:


### PR DESCRIPTION
## Description
Just noticed within the Red Hat Developer Hub Operator OCP installation page, that when the user clicks the `Configuring external PostgreSQL databases` link they get navigated to a 404 page.
![Screenshot from 2024-12-10 11-01-28](https://github.com/user-attachments/assets/87183152-30e2-4b4b-bb91-5fdc486d6ea1)


## Which issue(s) does this PR fix or relate to

N/A

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
May need to include this change in the build so the change gets reflected downstream.