### PR TITLE
fix: adjust startup, liveness and readiness probes settings

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2024-11-26T21:42:16Z"
+    createdAt: "2024-12-13T13:52:40Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2024-12-13T13:52:40Z"
+    createdAt: "2024-12-13T14:46:15Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
-    createdAt: "2024-12-13T10:42:18Z"
+    createdAt: "2024-12-13T13:52:41Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
-    createdAt: "2024-11-27T12:15:30Z"
+    createdAt: "2024-12-13T10:42:18Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
-    createdAt: "2024-12-13T13:52:41Z"
+    createdAt: "2024-12-13T14:46:16Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -258,7 +258,7 @@ data:
                   path: /.backstage/health/v1/liveness
                   port: backend
                   scheme: HTTP
-                initialDelaySeconds: 60
+                initialDelaySeconds: 30
                 timeoutSeconds: 4
                 periodSeconds: 20
                 successThreshold: 1
@@ -269,6 +269,10 @@ data:
                   path: /.backstage/health/v1/readiness
                   port: backend
                   scheme: HTTP
+                # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+                # The startup probe is already configured to give enough time for the application to be started.
+                # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+                # which helps make the application available faster to the end-user.
                 #initialDelaySeconds: 30
                 periodSeconds: 10
                 successThreshold: 2
@@ -279,6 +283,10 @@ data:
                   path: /.backstage/health/v1/liveness
                   port: backend
                   scheme: HTTP
+                # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+                # The startup probe is already configured to give enough time for the application to be started.
+                # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+                # which helps make the application available faster to the end-user.
                 #initialDelaySeconds: 60
                 periodSeconds: 10
                 successThreshold: 1

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -251,26 +251,38 @@ data:
                   type: RuntimeDefault
                 runAsNonRoot: true
                 allowPrivilegeEscalation: false
+              startupProbe:
+                # This gives enough time upon container startup before the liveness and readiness probes are triggered.
+                # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
+                httpGet:
+                  path: /.backstage/health/v1/liveness
+                  port: backend
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                timeoutSeconds: 4
+                periodSeconds: 20
+                successThreshold: 1
+                failureThreshold: 3
               readinessProbe:
                 failureThreshold: 3
                 httpGet:
-                  path: /healthcheck
-                  port: 7007
+                  path: /.backstage/health/v1/readiness
+                  port: backend
                   scheme: HTTP
-                initialDelaySeconds: 30
+                #initialDelaySeconds: 30
                 periodSeconds: 10
                 successThreshold: 2
-                timeoutSeconds: 2
+                timeoutSeconds: 4
               livenessProbe:
                 failureThreshold: 3
                 httpGet:
-                  path: /healthcheck
-                  port: 7007
+                  path: /.backstage/health/v1/liveness
+                  port: backend
                   scheme: HTTP
-                initialDelaySeconds: 60
+                #initialDelaySeconds: 60
                 periodSeconds: 10
                 successThreshold: 1
-                timeoutSeconds: 2
+                timeoutSeconds: 4
               ports:
                 - name: backend
                   containerPort: 7007

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -258,7 +258,7 @@ data:
                   path: /.backstage/health/v1/liveness
                   port: backend
                   scheme: HTTP
-                initialDelaySeconds: 60
+                initialDelaySeconds: 30
                 timeoutSeconds: 4
                 periodSeconds: 20
                 successThreshold: 1

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -258,7 +258,7 @@ data:
                   path: /.backstage/health/v1/liveness
                   port: backend
                   scheme: HTTP
-                initialDelaySeconds: 30
+                initialDelaySeconds: 60
                 timeoutSeconds: 4
                 periodSeconds: 20
                 successThreshold: 1

--- a/config/profile/rhdh/default-config/deployment.yaml
+++ b/config/profile/rhdh/default-config/deployment.yaml
@@ -96,26 +96,38 @@ spec:
               type: RuntimeDefault
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+          startupProbe:
+            # This gives enough time upon container startup before the liveness and readiness probes are triggered.
+            # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
+            httpGet:
+              path: /.backstage/health/v1/liveness
+              port: backend
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 4
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthcheck
-              port: 7007
+              path: /.backstage/health/v1/readiness
+              port: backend
               scheme: HTTP
-            initialDelaySeconds: 30
+            #initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 2
-            timeoutSeconds: 2
+            timeoutSeconds: 4
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthcheck
-              port: 7007
+              path: /.backstage/health/v1/liveness
+              port: backend
               scheme: HTTP
-            initialDelaySeconds: 60
+            #initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 4
           ports:
             - name: backend
               containerPort: 7007

--- a/config/profile/rhdh/default-config/deployment.yaml
+++ b/config/profile/rhdh/default-config/deployment.yaml
@@ -103,7 +103,7 @@ spec:
               path: /.backstage/health/v1/liveness
               port: backend
               scheme: HTTP
-            initialDelaySeconds: 60
+            initialDelaySeconds: 30
             timeoutSeconds: 4
             periodSeconds: 20
             successThreshold: 1
@@ -114,6 +114,10 @@ spec:
               path: /.backstage/health/v1/readiness
               port: backend
               scheme: HTTP
+            # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+            # The startup probe is already configured to give enough time for the application to be started.
+            # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+            # which helps make the application available faster to the end-user.
             #initialDelaySeconds: 30
             periodSeconds: 10
             successThreshold: 2
@@ -124,6 +128,10 @@ spec:
               path: /.backstage/health/v1/liveness
               port: backend
               scheme: HTTP
+            # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+            # The startup probe is already configured to give enough time for the application to be started.
+            # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+            # which helps make the application available faster to the end-user.
             #initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
This aligns with the changes in the Helm Chart - see https://github.com/redhat-developer/rhdh-chart/pull/50

Startup probe settings seem to have been added in the upstream Backstage Chart
in [1], but the current settings do not allow the liveness probe to be triggered sufficiently enough for the app to be
considered live.
This adjusts such settings by accounting for the worst-case scenario where the application might take a bit long to start.

This also aligns the probe endpoints with the Helm chart.

[1] https://github.com/backstage/charts/pull/216

## Which issue(s) does this PR fix or relate to

- Relates to https://github.com/redhat-developer/rhdh-chart/pull/50
- Relates to [issues.redhat.com/browse/RHIDP-5106](https://issues.redhat.com/browse/RHIDP-5106)
- Relates to [issues.redhat.com/browse/RHIDP-4968](https://issues.redhat.com/browse/RHIDP-4968)

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
