### PR TITLE
chore: tagRelease.sh: bump to 1.4.1 in release-1.4 branch

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml
@@ -59,11 +59,11 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
-    skipRange: '>=1.0.0 <1.4.0'
+    skipRange: '>=1.0.0 <1.4.1'
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
-  name: rhdh-operator.v1.4.0
+  name: rhdh-operator.v1.4.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -368,4 +368,4 @@ spec:
     name: Red Hat Inc.
     url: https://www.redhat.com/
   replaces: rhdh-operator.v1.3.1
-  version: 1.4.0
+  version: 1.4.1

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.4.0
+VERSION ?= 0.4.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,13 +35,13 @@ metadata:
           }
         }
       ]
-    createdAt: "2024-12-13T14:46:15Z"
+    createdAt: "2024-12-17T22:26:38Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   labels:
     operatorframework.io/arch.amd64: supported
-  name: backstage-operator.v0.4.0
+  name: backstage-operator.v0.4.1
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -195,7 +195,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/rhdh-community/operator:0.4.0
+                image: quay.io/rhdh-community/operator:0.4.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -302,4 +302,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
-  version: 0.4.0
+  version: 0.4.1

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
-    createdAt: "2024-12-13T14:46:16Z"
+    createdAt: "2024-12-17T22:26:39Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed
@@ -245,7 +245,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/rhdh/rhdh-hub-rhel9:1.4
-                image: quay.io/rhdh-community/operator:0.4.0
+                image: quay.io/rhdh-community/operator:0.4.1
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
-  name: backstage-operator.v0.4.0
+  name: backstage-operator.v0.4.1
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -364,4 +364,4 @@ spec:
   - image: quay.io/rhdh/rhdh-hub-rhel9:1.4
     name: backstage
   replaces: rhdh-operator.v1.2.0
-  version: 0.4.0
+  version: 0.4.1

--- a/config/profile/backstage.io/kustomization.yaml
+++ b/config/profile/backstage.io/kustomization.yaml
@@ -136,7 +136,7 @@ resources:
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.4.0
+  newTag: 0.4.1
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/profile/rhdh/kustomization.yaml
+++ b/config/profile/rhdh/kustomization.yaml
@@ -136,7 +136,7 @@ resources:
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.4.0
+  newTag: 0.4.1
 
 patches:
 - patch: |-


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
