### PR TITLE
chore: tagRelease.sh: bump to 1.3.4 in release-1.3 branch

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -42,8 +42,8 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
     support: Red Hat
-    skipRange: '>=1.0.0 <1.3.3'
-  name: rhdh-operator.v1.3.3
+    skipRange: '>=1.0.0 <1.3.4'
+  name: rhdh-operator.v1.3.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -356,5 +356,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
-  version: 1.3.3
+  version: 1.3.4
   replaces: rhdh-operator.v1.1.1

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.3.2
+VERSION ?= 0.3.4
 
 # Using docker or podman to build and push images
 CONTAINER_ENGINE ?= docker

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-11-26T19:22:51Z"
+    createdAt: "2024-12-17T22:34:51Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    skipRange: '>=0.0.1 <0.3.4'
+    skipRange: '>=0.0.1 <0.3.2'
   name: backstage-operator.v0.3.4
   namespace: placeholder
 spec:
@@ -214,7 +214,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/rhdh/rhdh-hub-rhel9:1.3
-                image: quay.io/rhdh-community/operator:0.3.2
+                image: quay.io/rhdh-community/operator:0.3.4
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,8 +25,8 @@ metadata:
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    skipRange: '>=0.0.1 <0.3.2'
-  name: backstage-operator.v0.3.2
+    skipRange: '>=0.0.1 <0.3.4'
+  name: backstage-operator.v0.3.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -316,4 +316,4 @@ spec:
   - image: quay.io/rhdh/rhdh-hub-rhel9:1.3
     name: backstage
   replaces: backstage-operator.v0.2.0
-  version: 0.3.2
+  version: 0.3.4

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.3.2
+  newTag: 0.3.4
 patches:
 - patch: |-
     - op: replace


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
