### PR TITLE
chore(renovate): Remove EOL 1.2.x from the Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,8 +12,7 @@
   ],
   "baseBranches": [
     "main",
-    "/^release-1\\..*/",
-    "/^1\\.2\\.x/"
+    "/^release-1\\..*/"
   ],
   "constraints": {
     "go": "1.22"
@@ -69,9 +68,8 @@
         "minor"
       ],
       "matchBaseBranches": [
-        "/^release-1\\.3/",
-        "/^1\\.2\\.x/"
-      ],      
+        "/^release-1\\..*/"
+      ],
       "automerge": false
     },  
     {
@@ -84,7 +82,7 @@
         "patch"
       ],
       "additionalBranchPrefix": "dockerfile ",
-      "groupName": "All dockerfile images",      
+      "groupName": "All dockerfile images",
       "automerge": true,
       "pinDigests": false
     },


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
1.2 is now EOL with the release of 1.4. This PR updates the Renovate config so we don't get any dependency update PRs against that branch.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
Not tested - we'll monitor the repo once this PR is merged