### PR TITLE
ci: Fix issue that could skip PR container builds if the fork repo is outdated

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -39,8 +39,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -49,8 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       # check changes in this commit for regex include and exclude matches; pipe to an env var
       - name: Check for changes to build


### PR DESCRIPTION
## Description
Checking out the PR fork repo could sometimes cause the "git diff" command to return an invalid revision range, like in [1].
This might happen if the fork repo is outdated.

To overcome this, this PR checks out the merge commit instead. That's also what GH does by default.

[1] https://github.com/redhat-developer/rhdh-operator/actions/runs/12417737622/job/34715972414?pr=582

## Which issue(s) does this PR fix or relate to

https://github.com/redhat-developer/rhdh-operator/actions/runs/12417737622/job/34715972414?pr=582
I wanted to review and test #582 but realized no container was built for it. Based on the changes in that PR, it should have containers built.

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
We need to merge this first to see it in action and validate the behavior.