### PR TITLE
ci: Fix the E2E nightly upgrade tests

### DIFF
--- a/tests/e2e/testdata/rhdh-operator-1.3.yaml
+++ b/tests/e2e/testdata/rhdh-operator-1.3.yaml
@@ -1478,7 +1478,7 @@ spec:
           value: quay.io/fedora/postgresql-15:latest
         - name: RELATED_IMAGE_backstage
           value: quay.io/rhdh/rhdh-hub-rhel9:1.3
-        image: quay.io/rhdh-community/operator:0.3.2
+        image: quay.io/rhdh-community/operator:0.3.4
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/e2e/testdata/rhdh-operator-1.4.yaml
+++ b/tests/e2e/testdata/rhdh-operator-1.4.yaml
@@ -1952,7 +1952,7 @@ spec:
           value: quay.io/fedora/postgresql-15:latest
         - name: RELATED_IMAGE_backstage
           value: quay.io/rhdh/rhdh-hub-rhel9:1.4
-        image: quay.io/rhdh-community/operator:0.4.0
+        image: quay.io/rhdh-community/operator:0.4.1
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Description
The tags used in the test seem to have expired from quay.io/rhdh-community/operator

## Which issue(s) does this PR fix or relate to

https://github.com/redhat-developer/rhdh-operator/actions/workflows/nightly-upgrade-test.yaml

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
`make test-e2e-upgrade`  should pass
