### PR TITLE
ci: Fix issue preventing the bundle diff checker job from committing changes detected

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   authorize:
@@ -39,7 +39,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5


### PR DESCRIPTION
## Description
Checking out the merge commit causes us to no longer be on the PR branch, as we can see in these logs [1].

[1] https://github.com/redhat-developer/rhdh-operator/actions/runs/12632058905/job/35222737737

## Which issue(s) does this PR fix or relate to

This is to fix the CI issues detected in #622. 

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
