### PR TITLE
Sort external config data for hash consistency (fix for RHIDP-5411)

### DIFF
--- a/internal/controller/preprocessor_test.go
+++ b/internal/controller/preprocessor_test.go
@@ -84,3 +84,16 @@ func TestExtConfigChanged(t *testing.T) {
 	assert.Equal(t, "false", cm.Labels[model.ExtConfigSyncLabel])
 
 }
+
+// TestExtConfigChanged tests if concatData returns the same data when the order of the keys is different
+func TestExtConcatData(t *testing.T) {
+	cm := corev1.ConfigMap{}
+
+	cm.Data = map[string]string{"key1": "value1", "key2": "value2", "key3": "value3", "key4": "value4"}
+	original := []byte("original")
+	data1 := concatData(original, &cm)
+
+	cm.Data = map[string]string{"key4": "value4", "key2": "value2", "key3": "value3", "key1": "value1"}
+	assert.Equal(t, data1, concatData(original, &cm))
+
+}


### PR DESCRIPTION
## Description
Added sort for external config data for hash consistency

## Which issue(s) does this PR fix or relate to

https://issues.redhat.com/browse/RHIDP-5411

## PR acceptance criteria

- [X] Tests


