### PR TITLE
ci: Fix the changed files detection when running some of the Workflows

### DIFF
--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -51,7 +51,15 @@ jobs:
             **/*.md
             **/*.adoc
             .rhdh/**
-            tests/**
+            tests/** 
+
+      - name: List all changed files (for troubleshooting)
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
 
       - name: Get the last commit short SHA
         # run this stage only if there are changes that match the includes and not the excludes

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -29,27 +29,33 @@ jobs:
         with:
           fetch-depth: 0
 
-      # check changes in this commit for regex include and exclude matches; pipe to an env var
-      - name: Check for changes to build
-        run: |
-          # don't fail if nothing returned by grep
-          set +e 
-          CHANGES="$(git diff --name-only HEAD~1 | \
-            grep -E "workflows/.+-container-build.yaml|Makefile|bundle/|config/|go.mod|go.sum|.+\.go|docker/|\.dockerignore" | \
-            grep -v -E ".+_test.go|/.rhdh/")";
-          echo "Changed files for this commit:"
-          echo "=============================="
-          echo "$CHANGES"
-          echo "=============================="
-          {
-            echo 'CHANGES<<EOF'
-            echo $CHANGES
-            echo EOF
-          } >> "$GITHUB_ENV"
+      # check changes in this commit for regex include and exclude matches
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
+        with:
+          files: |
+            .github/workflows/next-container-build.yaml
+            Makefile
+            **/*.go
+            bundle/**
+            config/**
+            go.mod
+            go.sum
+            LICENSE
+            **/Dockerfile
+            **/Containerfile
+            **/*.Dockerfile
+            **/.dockerignore
+          files_ignore: |
+            **/*.md
+            **/*.adoc
+            .rhdh/**
+            tests/**
 
       - name: Get the last commit short SHA
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
@@ -58,14 +64,14 @@ jobs:
 
       - name: Setup Go
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5
         with:
           go-version-file: 'go.mod'
 
       - name: Login to quay.io
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -74,7 +80,7 @@ jobs:
 
       - name: Build and push operator, bundle, and catalog images
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           # install skopeo, podman
           sudo apt-get -y update; sudo apt-get -y install skopeo podman

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -74,7 +74,15 @@ jobs:
             **/*.md
             **/*.adoc
             .rhdh/**
-            tests/**
+            tests/** 
+
+      - name: List all changed files (for troubleshooting)
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
 
       - name: Setup Go
         # run this stage only if there are changes that match the includes and not the excludes

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -49,36 +49,43 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.ref }}
 
-      # check changes in this commit for regex include and exclude matches; pipe to an env var
-      - name: Check for changes to build
-        run: |
-          # don't fail if nothing returned by grep
-          set +e 
-          CHANGES="$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | \
-            grep -E "workflows/.+-container-build.yaml|Makefile|bundle/|config/|go.mod|go.sum|.+\.go|docker/|\.dockerignore" | \
-            grep -v -E ".+_test.go|/.rhdh/")";
-          echo "Changed files for this commit:"
-          echo "=============================="
-          echo "$CHANGES"
-          echo "=============================="
-          {
-            echo 'CHANGES<<EOF'
-            echo $CHANGES
-            echo EOF
-          } >> "$GITHUB_ENV"
+      # check changes in this commit for regex include and exclude matches
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
+        with:
+          files: |
+            .github/workflows/pr-container-build.yaml
+            Makefile
+            **/*.go
+            bundle/**
+            config/**
+            go.mod
+            go.sum
+            LICENSE
+            **/Dockerfile
+            **/Containerfile
+            **/*.Dockerfile
+            **/.dockerignore
+          files_ignore: |
+            **/*.md
+            **/*.adoc
+            .rhdh/**
+            tests/**
 
       - name: Setup Go
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5
         with:
           go-version-file: 'go.mod'
 
       - name: Get the last commit short SHA of the PR
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           SHORT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
@@ -87,7 +94,7 @@ jobs:
 
       - name: Login to quay.io
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -96,7 +103,7 @@ jobs:
 
       - name: Build and push operator, bundle, and catalog images
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           # install skopeo, podman
           sudo apt-get -y update; sudo apt-get -y install skopeo podman
@@ -120,7 +127,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
       - name: Comment image links in PR
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,15 @@ jobs:
           files_ignore: |
             **/*.md
             **/*.adoc
-            .rhdh/**
+            .rhdh/** 
+
+      - name: List all changed files (for troubleshooting)
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
 
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,23 +18,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      # check changes in this commit for regex include and exclude matches; pipe to an env var
-      - name: Check for changes to build
-        run: |
-          # don't fail if nothing returned by grep
-          set +e 
-          CHANGES="$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | \
-            grep -E "workflows/pr.yaml|Makefile|bundle/|config/|go.mod|go.sum|.+\.go" | \
-            grep -v -E "/.rhdh/")";
-          echo "Changed files for this commit:"
-          echo "=============================="
-          echo "$CHANGES"
-          echo "=============================="
-          {
-            echo 'CHANGES<<EOF'
-            echo $CHANGES
-            echo EOF
-          } >> "$GITHUB_ENV"
+      # check changes in this commit for regex include and exclude matches
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
+        with:
+          files: |
+            .github/workflows/pr.yaml
+            Makefile
+            **/*.go
+            bundle/**
+            config/**
+            go.mod
+            go.sum
+          files_ignore: |
+            **/*.md
+            **/*.adoc
+            .rhdh/**
 
       - name: Setup Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5
@@ -47,28 +47,28 @@ jobs:
 
       - name: Start Minikube
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
-        uses: medyagh/setup-minikube@latest
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # v0.0.18
 
       - name: Run Controller
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make install run &
 
       - name: Test
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make test
 
       - name: Generic Integration test
         # run this stage only if there are changes that match the includes and not the excludes
         # perform it on backstage.io for speed
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make integration-test PROFILE=backstage.io USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true
 
       - name: RHDH specific Integration test
         # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make integration-test ARGS='--focus "create default rhdh"' USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true
 
       - name: Run Gosec Security Scanner


### PR DESCRIPTION
## Description
In some cases, for some reason, no change would be detected.
This was noticed in several PRs where, for example, container images should have been built but were skipped because the diff was being executed against the base commit at the time the PR was created, with errors similar to the following in the logs [1]:
```
fatal: Invalid revision range 5df8826c3b5e2c1d8c8f782fa616b19efd83330c..5f054315e9139f6098d7a84658c1e066987de045
Changed files for this commit:
==============================

==============================
```

This should hopefully fix that behavior, by delegating to https://github.com/tj-actions/changed-files.

The way the exclusion and inclusion rules are defined also makes the Workflows much more legible.

[1] https://github.com/redhat-developer/rhdh-operator/actions/runs/12637951503/job/35213226116?pr=609#step:3:20

## Which issue(s) does this PR fix or relate to

https://github.com/redhat-developer/rhdh-operator/actions/runs/12637951503/job/35213226116?pr=609#step:3:20

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.clusterserviceversion.yaml`](../.rhdh/bundle/manifests/rhdh-operator.clusterserviceversion.yaml) file accordingly

## How to test changes / Special notes to the reviewer
Let's see if this works.
