### PR TITLE
ci: Check install and airgap scripts in CI [RHIDP 5162]

### DIFF
--- a/.github/workflows/scripts-checks.yaml
+++ b/.github/workflows/scripts-checks.yaml
@@ -1,0 +1,41 @@
+name: Differential ShellCheck
+
+on:
+  push:
+    paths:
+      - '**.sh'
+    branches: [ main ]
+  pull_request:
+    paths:
+      - '**.sh'
+    branches: [ 'main' ]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck-lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          # Differential ShellCheck requires full git history
+          fetch-depth: 0
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@5fa026e4797665181a0f7c6fa4a73c09348ae78c # v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: always()
+        name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}

--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -305,7 +305,7 @@ function merge_registry_auth() {
   if [[ -n "${TO_REGISTRY}" ]]; then
     images+=("$(buildRegistryUrl)")
   fi
-  registries=()
+  registries=("registry.redhat.io" "quay.io")
   for img in "${images[@]}"; do
     reg=$(echo "$img" | cut -d'/' -f1)
     [[ " ${registries[*]} " =~ " $reg " ]] || registries+=("$reg")


### PR DESCRIPTION
## Description

This introduces ShellCheck for checking our scripts (including the CI and airgap ones) in CI.
It leverages https://github.com/redhat-plumbers-in-action/differential-shellcheck

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-5162

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
