### PR TITLE
Make initContainer root filesystem read-only

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-02-03T00:37:44Z"
+    createdAt: "2025-02-07T19:24:58Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.5
-    createdAt: "2025-02-03T00:37:46Z"
+    createdAt: "2025-02-07T19:25:00Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -162,7 +162,7 @@ data:
           securityContext:
             # any group id
             fsGroup: 1001
-  deployment.yaml: |-
+  deployment.yaml: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -171,11 +171,11 @@ data:
       replicas: 1
       selector:
         matchLabels:
-          rhdh.redhat.com/app:  # placeholder for 'backstage-<cr-name>'
+          rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'
       template:
         metadata:
           labels:
-            rhdh.redhat.com/app:  # placeholder for 'backstage-<cr-name>'
+            rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'
         spec:
           automountServiceAccountToken: false
           # if securityContext not present in AKS/EKS, the error is like this:
@@ -205,6 +205,8 @@ data:
                 secretName: dynamic-plugins-registry-auth
             - emptyDir: {}
               name: npmcacache
+            - name: temp
+              emptyDir: {}
           initContainers:
             - name: install-dynamic-plugins
               command:
@@ -214,6 +216,7 @@ data:
               image: quay.io/rhdh/rhdh-hub-rhel9:next
               imagePullPolicy: IfNotPresent
               securityContext:
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
                 allowPrivilegeEscalation: false
                 seccompProfile:
@@ -236,6 +239,8 @@ data:
                   readOnly: true
                 - mountPath: /opt/app-root/src/.npm/_cacache
                   name: npmcacache
+                - mountPath: /tmp
+                  name: temp
               workingDir: /opt/app-root/src
               resources:
                 requests:
@@ -310,6 +315,8 @@ data:
               volumeMounts:
                 - mountPath: /opt/app-root/src/dynamic-plugins-root
                   name: dynamic-plugins-root
+                - mountPath: /tmp
+                  name: temp
               resources:
                 requests:
                   cpu: 250m

--- a/config/profile/rhdh/default-config/deployment.yaml
+++ b/config/profile/rhdh/default-config/deployment.yaml
@@ -6,11 +6,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      rhdh.redhat.com/app:  # placeholder for 'backstage-<cr-name>'
+      rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'
   template:
     metadata:
       labels:
-        rhdh.redhat.com/app:  # placeholder for 'backstage-<cr-name>'
+        rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'
     spec:
       automountServiceAccountToken: false
       # if securityContext not present in AKS/EKS, the error is like this:
@@ -40,6 +40,8 @@ spec:
             secretName: dynamic-plugins-registry-auth
         - emptyDir: {}
           name: npmcacache
+        - name: temp
+          emptyDir: {}
       initContainers:
         - name: install-dynamic-plugins
           command:
@@ -49,6 +51,7 @@ spec:
           image: quay.io/rhdh/rhdh-hub-rhel9:next
           imagePullPolicy: IfNotPresent
           securityContext:
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             seccompProfile:
@@ -71,6 +74,8 @@ spec:
               readOnly: true
             - mountPath: /opt/app-root/src/.npm/_cacache
               name: npmcacache
+            - mountPath: /tmp
+              name: temp
           workingDir: /opt/app-root/src
           resources:
             requests:
@@ -145,6 +150,8 @@ spec:
           volumeMounts:
             - mountPath: /opt/app-root/src/dynamic-plugins-root
               name: dynamic-plugins-root
+            - mountPath: /tmp
+              name: temp
           resources:
             requests:
               cpu: 250m


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Sets the readOnlyRootFilesystem:true on the initContainer, has been tested with 1.3.x, 1.4.x, and next images

## Which issue(s) does this PR fix or relate to

https://issues.redhat.com/browse/RHIDP-5887

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
