### PR TITLE
chore: enableReadOnlyRootFilesystem by default on backend container

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-03-12T09:28:10Z"
+    createdAt: "2025-03-19T17:41:51Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.6
-    createdAt: "2025-03-12T09:28:12Z"
+    createdAt: "2025-03-19T17:41:52Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -277,6 +277,7 @@ data:
                   type: RuntimeDefault
                 runAsNonRoot: true
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
               startupProbe:
                 # This gives enough time upon container startup before the liveness and readiness probes are triggered.
                 # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.

--- a/config/profile/rhdh/default-config/deployment.yaml
+++ b/config/profile/rhdh/default-config/deployment.yaml
@@ -101,6 +101,7 @@ spec:
               type: RuntimeDefault
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           startupProbe:
             # This gives enough time upon container startup before the liveness and readiness probes are triggered.
             # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -1782,6 +1782,7 @@ data:
                   type: RuntimeDefault
                 runAsNonRoot: true
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
               startupProbe:
                 # This gives enough time upon container startup before the liveness and readiness probes are triggered.
                 # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Enables the readOnlyRootFilesystem option on the backend container by default for RHDH 1.6

## Which issue(s) does this PR fix or relate to

https://issues.redhat.com/browse/RHIDP-5893

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
