### PR TITLE
chore: tagRelease.sh: bump to 1.3.6 in release-1.3 branch

### DIFF
--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-02-13T21:21:09Z"
+    createdAt: "2025-02-28T13:41:31Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    skipRange: '>=0.0.1 <0.3.6'
+    skipRange: '>=0.0.1 <0.3.2'
   name: backstage-operator.v0.3.6
   namespace: placeholder
 spec:

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    skipRange: '>=0.0.1 <0.3.2'
+    skipRange: '>=0.0.1 <0.3.6'
   name: backstage-operator.v0.3.6
   namespace: placeholder
 spec:


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
