### PR TITLE
chore: Add warning comment advising against editing the default ConfigMaps manually in the cluster

### DIFF
--- a/bundle/backstage.io/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/backstage.io/manifests/backstage-default-config_v1_configmap.yaml
@@ -7,6 +7,16 @@ data:
       name: my-backstage-config-cm1 # placeholder for <bs>-default-appconfig
     data:
       default.app-config.yaml: |
+        ###########################################################################################################
+        # /!\ WARNING
+        #
+        # This is the default app-config file created and managed by the Operator for your CR.
+        # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+        # next reconciliation.
+        # If you want to customize the application configuration, you should create your own app-config ConfigMap
+        # and reference it in your CR.
+        # See https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml for an example.
+        ###########################################################################################################
         backend:
           auth:
             externalAccess:

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-03-06T18:59:19Z"
+    createdAt: "2025-03-12T09:28:10Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.6
-    createdAt: "2025-03-06T18:59:20Z"
+    createdAt: "2025-03-12T09:28:12Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -7,6 +7,17 @@ data:
       name: my-backstage-config-cm1 # placeholder for <bs>-default-appconfig
     data:
       default.app-config.yaml: |
+        ###########################################################################################################
+        # /!\ WARNING
+        #
+        # This is the default app-config file created and managed by the Operator for your CR.
+        # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+        # next reconciliation.
+        # If you want to customize the application configuration, you should create your own app-config ConfigMap
+        # and reference it in your CR.
+        # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/configuring/provisioning-and-using-your-custom-configuration#provisioning-your-custom-configuration
+        # for more details.
+        ###########################################################################################################
         backend:
           auth:
             externalAccess:
@@ -343,6 +354,18 @@ data:
       name: default-dynamic-plugins #  must be the same as (deployment.yaml).spec.template.spec.volumes.name.dynamic-plugins-conf.configMap.name
     data:
       "dynamic-plugins.yaml": |
+        ###########################################################################################################
+        # /!\ WARNING
+        #
+        # This is the default dynamic plugins configuration file created and managed by the Operator for your CR.
+        # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+        # next reconciliation.
+        # If you want to customize the dynamic plugins, you should create your own dynamic-plugins ConfigMap
+        # and reference it in your CR.
+        # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-installing-rhdh-plugins_title-plugins-rhdh-about#proc-config-dynamic-plugins-rhdh-operator_rhdh-installing-rhdh-plugins
+        # for more details or https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml
+        # for an example.
+        ###########################################################################################################
         includes:
           - dynamic-plugins.default.yaml
         plugins: []

--- a/config/profile/backstage.io/default-config/app-config.yaml
+++ b/config/profile/backstage.io/default-config/app-config.yaml
@@ -4,6 +4,16 @@ metadata:
   name: my-backstage-config-cm1 # placeholder for <bs>-default-appconfig
 data:
   default.app-config.yaml: |
+    ###########################################################################################################
+    # /!\ WARNING
+    #
+    # This is the default app-config file created and managed by the Operator for your CR.
+    # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+    # next reconciliation.
+    # If you want to customize the application configuration, you should create your own app-config ConfigMap
+    # and reference it in your CR.
+    # See https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml for an example.
+    ###########################################################################################################
     backend:
       auth:
         externalAccess:

--- a/config/profile/rhdh/default-config/app-config.yaml
+++ b/config/profile/rhdh/default-config/app-config.yaml
@@ -4,6 +4,17 @@ metadata:
   name: my-backstage-config-cm1 # placeholder for <bs>-default-appconfig
 data:
   default.app-config.yaml: |
+    ###########################################################################################################
+    # /!\ WARNING
+    #
+    # This is the default app-config file created and managed by the Operator for your CR.
+    # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+    # next reconciliation.
+    # If you want to customize the application configuration, you should create your own app-config ConfigMap
+    # and reference it in your CR.
+    # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/configuring/provisioning-and-using-your-custom-configuration#provisioning-your-custom-configuration
+    # for more details.
+    ###########################################################################################################
     backend:
       auth:
         externalAccess:

--- a/config/profile/rhdh/default-config/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/dynamic-plugins.yaml
@@ -4,6 +4,18 @@ metadata:
   name: default-dynamic-plugins #  must be the same as (deployment.yaml).spec.template.spec.volumes.name.dynamic-plugins-conf.configMap.name
 data:
   "dynamic-plugins.yaml": |
+    ###########################################################################################################
+    # /!\ WARNING
+    #
+    # This is the default dynamic plugins configuration file created and managed by the Operator for your CR.
+    # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+    # next reconciliation.
+    # If you want to customize the dynamic plugins, you should create your own dynamic-plugins ConfigMap
+    # and reference it in your CR.
+    # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-installing-rhdh-plugins_title-plugins-rhdh-about#proc-config-dynamic-plugins-rhdh-operator_rhdh-installing-rhdh-plugins
+    # for more details or https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml
+    # for an example.
+    ###########################################################################################################
     includes:
       - dynamic-plugins.default.yaml
     plugins: []

--- a/dist/backstage.io/install.yaml
+++ b/dist/backstage.io/install.yaml
@@ -1512,6 +1512,16 @@ data:
       name: my-backstage-config-cm1 # placeholder for <bs>-default-appconfig
     data:
       default.app-config.yaml: |
+        ###########################################################################################################
+        # /!\ WARNING
+        #
+        # This is the default app-config file created and managed by the Operator for your CR.
+        # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+        # next reconciliation.
+        # If you want to customize the application configuration, you should create your own app-config ConfigMap
+        # and reference it in your CR.
+        # See https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml for an example.
+        ###########################################################################################################
         backend:
           auth:
             externalAccess:

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -1512,6 +1512,17 @@ data:
       name: my-backstage-config-cm1 # placeholder for <bs>-default-appconfig
     data:
       default.app-config.yaml: |
+        ###########################################################################################################
+        # /!\ WARNING
+        #
+        # This is the default app-config file created and managed by the Operator for your CR.
+        # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+        # next reconciliation.
+        # If you want to customize the application configuration, you should create your own app-config ConfigMap
+        # and reference it in your CR.
+        # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/configuring/provisioning-and-using-your-custom-configuration#provisioning-your-custom-configuration
+        # for more details.
+        ###########################################################################################################
         backend:
           auth:
             externalAccess:
@@ -1848,6 +1859,18 @@ data:
       name: default-dynamic-plugins #  must be the same as (deployment.yaml).spec.template.spec.volumes.name.dynamic-plugins-conf.configMap.name
     data:
       "dynamic-plugins.yaml": |
+        ###########################################################################################################
+        # /!\ WARNING
+        #
+        # This is the default dynamic plugins configuration file created and managed by the Operator for your CR.
+        # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
+        # next reconciliation.
+        # If you want to customize the dynamic plugins, you should create your own dynamic-plugins ConfigMap
+        # and reference it in your CR.
+        # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-installing-rhdh-plugins_title-plugins-rhdh-about#proc-config-dynamic-plugins-rhdh-operator_rhdh-installing-rhdh-plugins
+        # for more details or https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml
+        # for an example.
+        ###########################################################################################################
         includes:
           - dynamic-plugins.default.yaml
         plugins: []


### PR DESCRIPTION
## Description
As seen several times on #forum-rhdh, some people used to manually edit the default app-config/dynamic-plugins ConfigMaps created by the Operator in the cluster and were surprised that they lost their changes.
This PR clarifies that by adding a warning in these default ConfigMaps and providing reference links for customizing their configuration.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
