### PR TITLE
ci: Add instructions on how to manually unblock stuck PRs after the bundle changes have been pushed

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   authorize:
@@ -82,5 +82,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ <b>Files changed in bundle and installer generation!</b><br/><br/>Those changes to the operator bundle/installer manifests should have been pushed automatically to your PR branch.'
+              body: '⚠️ <b>Files changed in bundle and installer generation!</b><br/><br/>Those changes to the operator bundle/installer manifests should have been pushed automatically to your PR branch.<br/><br/><b>NOTE: </b>If the PR checks are stuck after this additional commit, manually close the PR and immediately reopen it to trigger the checks again.'
             })


### PR DESCRIPTION
## Description
For context, because we are pushing using the GITHUB_TOKEN token,
GH prevents triggering subsequent workflows. See [1] and [2].

[1] https://github.com/orgs/community/discussions/25702#discussioncomment-3248819
[2] https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
