### PR TITLE
chore(yq): update prepare-restricted-environment.sh to support installing mikefarah yq

### DIFF
--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -61,7 +61,7 @@ function check_tool() {
 }
 
 function usage() {
-  FILTERED_VERSIONS_CSV="${FILTERED_VERSIONS[*]}"
+  FILTERED_VERSIONS_CSV="${FILTERED_VERSIONS[*]}"; FILTERED_VERSIONS_CSV="${FILTERED_VERSIONS_CSV// /,}"
   echo "
 This script streamlines the installation of the Red Hat Developer Hub Operator in a disconnected OpenShift or Kubernetes cluster.
 It supports partially disconnected as well as fully disconnected environments.


### PR DESCRIPTION
### What does this PR do?

chore(yq): update prepare-restricted-environment.sh to support use on machines where yq (jq python wrapper) is already installed (optionally, install the mikefarah yq to ~/.local/bin); 
also update defaults from 1.3/1.4 to 1.4/1.5 now that 1.3 is EOL; 
set default OCP to 4.18 as that's the latest EOL version

Signed-off-by: rhdh-bot service account <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHIDP-4415

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.