### PR TITLE
fix: Fix the airgap script on ROSA/HyperShift 4.18 by skipping the creation of an IDMS resource

### DIFF
--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -1151,7 +1151,9 @@ EOF
   fi
 fi
 
-if [[ -n "${TO_REGISTRY}" && "${IS_OPENSHIFT}" = "true" ]]; then
+# No longer possible to patch the OperatorHub resource on clusters with hosted control planes (ROSA 4.18).
+# More details in https://issues.redhat.com/browse/OCPBUGS-43431?focusedId=26463911&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26463911
+if [[ -n "${TO_REGISTRY}" ]] && [[ "${IS_OPENSHIFT}" == "true" ]] && [[ "${IS_HOSTED_CONTROL_PLANE}" != "true" ]]; then
   infof "Disabling the default Red Hat Ecosystem Catalog."
   invoke_cluster_cli patch OperatorHub cluster --type json \
       --patch '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'

--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -1139,9 +1139,12 @@ EOF
 EOF
     done
 
-    # Create the IDMS (OCP-specific) and CatalogSource
-    if [[ "${IS_OPENSHIFT}" = "true" ]]; then
-       invoke_cluster_cli apply -f "${manifestsTargetDir}/imageDigestMirrorSet.yaml"
+    # Create the IDMS (OCP-specific) and CatalogSource.
+    # IDMS resources never really worked on clusters with hosted control planes, and it looks like it is no longer
+    # possible to create them in ROSA/HyperShift 4.18. So skipping the IDMS creation for such clusters.
+    # More details in https://issues.redhat.com/browse/RHIDP-6684
+    if [[ "${IS_OPENSHIFT}" == "true" ]] && [[ "${IS_HOSTED_CONTROL_PLANE}" != "true" ]]; then
+      invoke_cluster_cli apply -f "${manifestsTargetDir}/imageDigestMirrorSet.yaml"
     fi
     debugf "Adding the internal cluster creds as pull secrets to be able to pull images from this internal registry by default"
     invoke_cluster_cli apply -f "${manifestsTargetDir}/catalogSource.yaml"


### PR DESCRIPTION
## Description

As depicted in https://issues.redhat.com/browse/RHIDP-6684, the creation of the IDMS is now being denied by the cluster on ROSA/HyperShift 4.18+

This PR detects the type of cluster (with a hosted control plane or not), and can decide whether to skip creating such forbidden resources.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-6684

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer

Create a ROSA 4.18 cluster, and run: `.rhdh/scripts/prepare-restricted-environment.sh` from this PR branch. It should work.
It should not affect regular OCP clusters or non-OCP clusters.
