### PR TITLE
chore: Fix the go-install-tool function in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,8 +503,15 @@ define go-install-tool
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
-mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
+GOBIN=$(LOCALBIN)/tmp go install $${package} ;\
+files=$$(ls $(LOCALBIN)/tmp | wc -l); \
+if [ "$$files" -ne 1 ]; then \
+	echo "Expected exactly one file in $(LOCALBIN)/tmp, found $$files"; \
+	ls -a "$(LOCALBIN)"/tmp ;\
+	exit 1; \
+fi; \
+echo "Moving $(LOCALBIN)/tmp/*" => $(1) ;\
+mv -f "$(LOCALBIN)"/tmp/* $(1) ;\
 }
 endef
 


### PR DESCRIPTION
## Description
Sometimes, it would randomly fail to move the go-install'ed binary for some reason (probably the sed operation).

This is an attempt at solving this and making it more reliable.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
