### PR TITLE
ci: Fix possible failures to find tool binaries (like `controller-gen`) in the test workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,7 +61,12 @@ jobs:
       - name: Run Controller
         # run this stage only if there are changes that match the includes and not the excludes
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: make install run &
+        run: |
+          # Need to 'make install' first, so that the necessary tool binaries (like controller-gen) can be downloaded locally.
+          # Otherwise, we might end up with a race condition where the tool binary is not yet downloaded,
+          # but the `make test` command tries to use it.
+          make manifests generate fmt vet install
+          make run &
 
       - name: Test
         # run this stage only if there are changes that match the includes and not the excludes


### PR DESCRIPTION
## Description

 We need to 'make install' first, so that the necessary tool binaries (like controller-gen) can be downloaded locally.

 Otherwise (because 'make install run' was started in the background),
 we might end up with a race condition where the tool binary is not yet downloaded,
 but the `make test` command
 in the subsequent step tries to use it.


## Which issue(s) does this PR fix or relate to

https://github.com/redhat-developer/rhdh-operator/actions/runs/14248198068/job/39934383296?pr=985

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
