### PR TITLE
fix(install script): Avoid catch-all mirrors in the ICSP resource when installing CI builds of the Operator on regular OCP clusters [RHIDP-7177]

### DIFF
--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -176,28 +176,6 @@ spec:
   - mirrors:
     - ${ICSP_URL}rhdh-hub-rhel9
     source: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-hub-rhel9
-
-  ## 2. general repo mappings
-  - mirrors:
-    - ${ICSP_URL_PRE}
-    source: registry.redhat.io
-  - mirrors:
-    - ${ICSP_URL_PRE}
-    source: registry.stage.redhat.io
-  - mirrors:
-    - ${ICSP_URL_PRE}
-    source: registry-proxy.engineering.redhat.com
-
-  ### now add mappings to resolve internal references
-  - mirrors:
-    - registry.redhat.io
-    source: registry.stage.redhat.io
-  - mirrors:
-    - registry.stage.redhat.io
-    source: registry-proxy.engineering.redhat.com
-  - mirrors:
-    - registry.redhat.io
-    source: registry-proxy.engineering.redhat.com
   " > "$TMPDIR/ImageContentSourcePolicy_${ICSP_URL_PRE}.yml" && oc apply -f "$TMPDIR/ImageContentSourcePolicy_${ICSP_URL_PRE}.yml" >&2
   fi
 


### PR DESCRIPTION
## Description
This PR removes the catch-all mirrors from the ICSP resource created when running the install script on regular OCP clusters. 

It seems this is now forbidden on clusters like OSD, because it would reportedly conflict with system registries.

Error message seen from the cluster, for reference:
```
Error from server (Forbidden): error when creating "/tmp/tmp.aIrEtibjvz/ImageContentSourcePolicy_quay.io.yml": admission webhook "imagecontentpolicies-validation.managed.openshift.io" denied the request: Managed OpenShift customers may not create ImageContentSourcePolicy, ImageDigestMirrorSet, or ImageTagMirrorSet resources that configure mirrors that would conflict with system registries (e.g. quay.io, registry.redhat.io, registry.access.redhat.com, etc). For more details, see https://docs.openshift.com/
[2025-04-23 08:04:46] newIIBImage=
[2025-04-23 08:04:46] rm -fr /tmp/tmp.aIrEtibjvz
```

These catch-all mirror settings should not be needed since we are already adding the right mirror settings for the images that we need.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-7177

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

/cc @subhashkhileri 