### PR TITLE
RHIDP-7360 added sealights steps

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,6 +17,7 @@ jobs:
           - release-1.6
           - release-1.5
           - release-1.4
+          
     name: 'E2E Tests on ${{ matrix.branch }}'
     concurrency:
       group: '${{ github.workflow }}-${{ matrix.branch }}'
@@ -29,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version-file: 'go.mod'
 
@@ -53,6 +54,7 @@ jobs:
           echo "OPERATOR_MANIFEST=${OPERATOR_MANIFEST}" >> $GITHUB_ENV
           OPERATOR_IMAGE=$(curl -s "${proto}${OPERATOR_MANIFEST}" | yq 'select(.kind == "Deployment" and .metadata.labels.app == "rhdh-operator") | .spec.template.spec.containers[0].image')
           echo "OPERATOR_IMAGE=${OPERATOR_IMAGE}" >> $GITHUB_ENV
+          echo "BUILD_TIME=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
 
       - name: Check if operator image exists in remote registry
         id: operator-image-existence-checker
@@ -75,6 +77,48 @@ jobs:
         run: |
           echo "K8S_INGRESS_DOMAIN=$(minikube ip).sslip.io" >> $GITHUB_ENV
 
+      - name: Download SeaLights Go agent and CLI tool
+        if: ${{ matrix.branch == 'main' }}
+        run: |
+            echo "[Sealights] Downloading Sealights Golang & CLI Agents..."
+            case $(lscpu | awk '/Architecture:/{print $2}') in
+              x86_64) SL_ARCH="linux-amd64";;
+              arm) SL_ARCH="linux-arm64";;
+            esac
+            wget -nv -O sealights-go-agent.tar.gz https://agents.sealights.co/slgoagent/latest/slgoagent-$SL_ARCH.tar.gz
+            wget -nv -O sealights-slcli.tar.gz https://agents.sealights.co/slcli/latest/slcli-$SL_ARCH.tar.gz
+            tar -xzf ./sealights-go-agent.tar.gz && tar -xzf ./sealights-slcli.tar.gz
+            rm -f ./sealights-go-agent.tar.gz ./sealights-slcli.tar.gz
+            ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
+
+      - name: Write SeaLights token into file
+        if: ${{ matrix.branch == 'main' }}
+        run: echo "${SEALIGHTS_AGENT_TOKEN}" > sltoken.txt
+        env:
+          SEALIGHTS_AGENT_TOKEN: '${{secrets.SEALIGHTS_AGENT_TOKEN}}' ## Make sure to add token to repo secrets
+
+      - name: Initiating the SeaLights agent
+        if: ${{ matrix.branch == 'main' }}
+        run: |
+          echo "[Sealights] Initiating the SeaLights agent to Golang and handing it the token"
+          ./slcli config init --lang go --token ./sltoken.txt
+
+      - name: Configuring SeaLights
+        if: ${{ matrix.branch == 'main' }} && ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
+        run: |
+          echo "[Sealights] Configuring SeaLights to scan for main branch nightly"
+          ./slcli config create-bsid --app rhdh-operator --branch main --build "$BUILD_TIME:$LATEST_COMMIT_SHA"
+        env:
+          LATEST_COMMIT_SHA: ${{ github.sha }}
+
+      - name: Run SeaLights scan for e2e tests
+        if: ${{ matrix.branch == 'main' }}
+        run: |
+          echo "[Sealights] Running the SeaLights e2e tests scan"
+          ./slcli scan --bsid buildSessionId.txt  --path-to-scanner ./slgoagent  --workspacepath "./" --scm git --scmBaseUrl https://github.com/redhat-developer/rhdh-operator --scmProvider github
+        env:
+          SEALIGHTS_TEST_STAGE: "E2E Tests Nightly"
+
       - name: Run E2E tests
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         env:
@@ -84,3 +128,9 @@ jobs:
           OPERATOR_MANIFEST: ${{ env.OPERATOR_MANIFEST }}
           IMG: ${{ env.OPERATOR_IMAGE }}
         run: make test-e2e
+
+      - name: Remove SeaLights secrets
+        if: ${{ matrix.branch == 'main' }}
+        run: |
+          echo "[Sealights] Cleaning up after SeaLights run"
+          rm sltoken.txt

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -76,30 +76,32 @@ jobs:
         run: |
           echo "K8S_INGRESS_DOMAIN=$(minikube ip).sslip.io" >> $GITHUB_ENV
 
-      - name: Download SeaLights Go agent and CLI tool
-        if: ${{ matrix.branch == 'main' }}
-        run: |
-            echo "[SeaLights] Downloading SeaLights Golang & CLI Agents..."
-            case $(lscpu | awk '/Architecture:/{print $2}') in
-              x86_64) SL_ARCH="linux-amd64";;
-              arm) SL_ARCH="linux-arm64";;
-            esac
-            wget -nv -O sealights-go-agent.tar.gz https://agents.sealights.co/slgoagent/latest/slgoagent-$SL_ARCH.tar.gz
-            wget -nv -O sealights-slcli.tar.gz https://agents.sealights.co/slcli/latest/slcli-$SL_ARCH.tar.gz
-            tar -xzf ./sealights-go-agent.tar.gz && tar -xzf ./sealights-slcli.tar.gz
-            rm -f ./sealights-go-agent.tar.gz ./sealights-slcli.tar.gz
-            ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
-
       - name: Write SeaLights token into file
         if: ${{ matrix.branch == 'main' }}
         run: echo "${SEALIGHTS_AGENT_TOKEN}" > sltoken.txt
         env:
           SEALIGHTS_AGENT_TOKEN: '${{secrets.SEALIGHTS_AGENT_TOKEN}}' ## Make sure to add token to repo secrets
 
+      - name: Download SeaLights Go agent and CLI tool
+        if: ${{ matrix.branch == 'main' }}
+        run: |
+            echo "[SeaLights] Downloading SeaLights Golang & CLI Agents..."
+            # Architectures available: darwin-amd64, darwin-arm64, linux-amd64, linux-arm64
+            SL_OS_ARCH=linux-amd64
+            SL_GO_AGENT_VERSION=v1.1.193
+            SL_CLI_AGENT_VERSION=v1.0.49
+
+            wget -nv -O sealights-go-agent.tar.gz https://agents.sealights.co/slgoagent/${SL_GO_AGENT_VERSION}/slgoagent-${SL_OS_ARCH}.tar.gz
+            wget -nv -O sealights-slcli.tar.gz https://agents.sealights.co/slcli/${SL_CLI_AGENT_VERSION}/slcli-${SL_OS_ARCH}.tar.gz
+
+            tar -xzf ./sealights-go-agent.tar.gz && tar -xzf ./sealights-slcli.tar.gz 
+            rm -f ./sealights-go-agent.tar.gz ./sealights-slcli.tar.gz 
+            ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
+
       - name: Initiating the SeaLights agent
         if: ${{ matrix.branch == 'main' }}
         run: |
-          echo "[Sealights] Initiating the SeaLights agent to Golang and handing it the token"
+          echo "[SeaLights] Initiating the SeaLights agent to Golang and handing it the token"
           ./slcli config init --lang go --token ./sltoken.txt
 
       - name: Configuring SeaLights

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -105,7 +105,7 @@ jobs:
           ./slcli config init --lang go --token ./sltoken.txt
 
       - name: Configuring SeaLights
-        if: ${{ matrix.branch == 'main' }} && ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
+        if: ${{ matrix.branch == 'main' && steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         run: |
           echo "[SeaLights] Configuring SeaLights to scan for main branch nightly"
           ./slcli config create-bsid --app rhdh-operator --branch main --build "$BUILD_TIME:$LATEST_COMMIT_SHA"
@@ -131,7 +131,7 @@ jobs:
         run: make test-e2e
 
       - name: Remove SeaLights secrets
-        if: ${{ matrix.branch == 'main' }}
+        if: always() && matrix.branch == 'main'
         run: |
           echo "[SeaLights] Cleaning up after SeaLights run"
           rm sltoken.txt

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,7 +17,6 @@ jobs:
           - release-1.6
           - release-1.5
           - release-1.4
-          
     name: 'E2E Tests on ${{ matrix.branch }}'
     concurrency:
       group: '${{ github.workflow }}-${{ matrix.branch }}'
@@ -80,7 +79,7 @@ jobs:
       - name: Download SeaLights Go agent and CLI tool
         if: ${{ matrix.branch == 'main' }}
         run: |
-            echo "[Sealights] Downloading Sealights Golang & CLI Agents..."
+            echo "[SeaLights] Downloading SeaLights Golang & CLI Agents..."
             case $(lscpu | awk '/Architecture:/{print $2}') in
               x86_64) SL_ARCH="linux-amd64";;
               arm) SL_ARCH="linux-arm64";;
@@ -106,7 +105,7 @@ jobs:
       - name: Configuring SeaLights
         if: ${{ matrix.branch == 'main' }} && ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         run: |
-          echo "[Sealights] Configuring SeaLights to scan for main branch nightly"
+          echo "[SeaLights] Configuring SeaLights to scan for main branch nightly"
           ./slcli config create-bsid --app rhdh-operator --branch main --build "$BUILD_TIME:$LATEST_COMMIT_SHA"
         env:
           LATEST_COMMIT_SHA: ${{ github.sha }}
@@ -114,7 +113,7 @@ jobs:
       - name: Run SeaLights scan for e2e tests
         if: ${{ matrix.branch == 'main' }}
         run: |
-          echo "[Sealights] Running the SeaLights e2e tests scan"
+          echo "[SeaLights] Running the SeaLights e2e tests scan"
           ./slcli scan --bsid buildSessionId.txt  --path-to-scanner ./slgoagent  --workspacepath "./" --scm git --scmBaseUrl https://github.com/redhat-developer/rhdh-operator --scmProvider github
         env:
           SEALIGHTS_TEST_STAGE: "E2E Tests Nightly"
@@ -132,5 +131,5 @@ jobs:
       - name: Remove SeaLights secrets
         if: ${{ matrix.branch == 'main' }}
         run: |
-          echo "[Sealights] Cleaning up after SeaLights run"
+          echo "[SeaLights] Cleaning up after SeaLights run"
           rm sltoken.txt


### PR DESCRIPTION

## Description
sealights integration specific to rhdh-operator nightly run

## Which issue(s) does this PR fix or relate to

- Fixes RHIDP-7360

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
Before merge please add SEALIGHTS_AGENT_TOKEN to repo secrets.
Tested on my forked branch
<img width="1319" alt="nightly" src="https://github.com/user-attachments/assets/a1bab1b1-4ead-4b70-8b3a-a7db8154705f" />

`if: ${{ matrix.branch == 'main' }}` is added to sealights steps to run only on main for now and not any other release branches as it overwrites the records with latest run. 