### PR TITLE
chore(log): Warn if metrics are served over plainttext HTTP

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,6 +63,10 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	if !secureMetrics {
+		setupLog.Info("Metrics are served over plaintext HTTP. This is only intended for local development.")
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
This adds a startup log warning when --metrics-secure=false is used,
to make it clear that exposing metrics without TLS/authn is only
intended for local development. Production bundles override this to true.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-7627

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
