### PR TITLE
chore: Update OWNERS with all members of the Install group

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,8 @@ approvers:
  - kadel
 
 reviewers:
+ - gazarenkov
+ - rm3l
  - Fortune-Ndlovu
  - subhashkhileri
  - zdrapela


### PR DESCRIPTION
## Description
Follow-up to https://github.com/redhat-developer/rhdh-operator/pull/1243

Actually set all members of the Install group as reviewers, as the Prow bot would request reviewers from people in the `reviewers` section.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
