### PR TITLE
ci: Fix the nightly tests [RHIDP-7804]

### DIFF
--- a/.github/workflows/nightly-upgrade-test.yaml
+++ b/.github/workflows/nightly-upgrade-test.yaml
@@ -94,14 +94,44 @@ jobs:
         run: |
           echo "::warning ::One of the operator images (${{ env.FROM_OPERATOR_IMAGE }} or ${{ env.TO_OPERATOR_IMAGE }}) could not be found for testing the ${{ matrix.from_branch }} => ${{ matrix.to_branch }} upgrade path. They might have expired. Skipping."
 
-      - name: Start Minikube
+      - name: Generate Kind Config
         if: ${{ steps.operator-image-existence-checker.outputs.FROM_OPERATOR_IMAGE_EXISTS == 'true' && steps.operator-image-existence-checker.outputs.TO_OPERATOR_IMAGE_EXISTS == 'true' }}
-        uses: medyagh/setup-minikube@cea33675329b799adccc9526aa5daccc26cd5052 # v0.0.19
+        run: |
+          cat <<EOF > /tmp/kind-config.yaml
+          apiVersion: kind.x-k8s.io/v1alpha4
+          kind: Cluster
+          nodes:
+            - role: control-plane
+              extraPortMappings:
+                - containerPort: 80
+                  hostPort: 80
+                  protocol: TCP
+                - containerPort: 443
+                  hostPort: 443
+                  protocol: TCP
+          EOF
+
+      - name: Create Kind cluster
+        if: ${{ steps.operator-image-existence-checker.outputs.FROM_OPERATOR_IMAGE_EXISTS == 'true' && steps.operator-image-existence-checker.outputs.TO_OPERATOR_IMAGE_EXISTS == 'true' }}
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: test-cluster
+          config: /tmp/kind-config.yaml
+          ignore_failed_clean: true
+
+      - name: Install Ingress Controller
+        if: ${{ steps.operator-image-existence-checker.outputs.FROM_OPERATOR_IMAGE_EXISTS == 'true' && steps.operator-image-existence-checker.outputs.TO_OPERATOR_IMAGE_EXISTS == 'true' }}
+        run: |
+          kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=90s
 
       - name: 'Run E2E tests (RHDH Operator Upgrade path: ${{ matrix.from_branch }} => ${{ matrix.to_branch }})'
         if: ${{ steps.operator-image-existence-checker.outputs.FROM_OPERATOR_IMAGE_EXISTS == 'true' && steps.operator-image-existence-checker.outputs.TO_OPERATOR_IMAGE_EXISTS == 'true' }}
         env:
-          BACKSTAGE_OPERATOR_TESTS_PLATFORM: minikube
+          BACKSTAGE_OPERATOR_TESTS_PLATFORM: kind
           PROFILE: 'rhdh'
           FROM_OPERATOR_MANIFEST: ${{ env.FROM_OPERATOR_MANIFEST }}
           TO_OPERATOR_MANIFEST: ${{ env.TO_OPERATOR_MANIFEST }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,16 +64,44 @@ jobs:
         run: |
           echo "::warning ::Operator Image ${{ env.OPERATOR_IMAGE }} not found for testing the ${{ matrix.branch }} branch. It might have expired. E2E tests will be skipped for ${{ matrix.branch }}."
 
-      - name: Start Minikube
+      - name: Generate Kind Config
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
-        uses: medyagh/setup-minikube@cea33675329b799adccc9526aa5daccc26cd5052 # v0.0.19
+        run: |
+          cat <<EOF > /tmp/kind-config.yaml
+          apiVersion: kind.x-k8s.io/v1alpha4
+          kind: Cluster
+          nodes:
+            - role: control-plane
+              extraPortMappings:
+                - containerPort: 80
+                  hostPort: 80
+                  protocol: TCP
+                - containerPort: 443
+                  hostPort: 443
+                  protocol: TCP
+          EOF
+
+      - name: Create Kind cluster
+        if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          addons: ingress
+          cluster_name: test-cluster
+          config: /tmp/kind-config.yaml
+          ignore_failed_clean: true
+
+      - name: Install Ingress Controller
+        if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
+        run: |
+          kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=90s
 
       - name: Build Ingress Domain
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         run: |
-          echo "K8S_INGRESS_DOMAIN=$(minikube ip).sslip.io" >> $GITHUB_ENV
+          echo "K8S_INGRESS_DOMAIN=127.0.0.1.sslip.io" >> $GITHUB_ENV
 
       - name: Write SeaLights token into file
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
@@ -167,7 +195,7 @@ jobs:
       - name: Run E2E tests
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         env:
-          BACKSTAGE_OPERATOR_TESTS_PLATFORM: minikube
+          BACKSTAGE_OPERATOR_TESTS_PLATFORM: kind
           BACKSTAGE_OPERATOR_TESTS_K8S_CREATE_INGRESS: 'true'
           BACKSTAGE_OPERATOR_TESTS_K8S_INGRESS_DOMAIN: ${{ env.K8S_INGRESS_DOMAIN }}
           OPERATOR_MANIFEST: ${{ env.OPERATOR_MANIFEST }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -131,6 +131,8 @@ jobs:
           # but the `make test` command tries to use it.
           make manifests generate fmt vet install
           make run &
+          MAKE_RUN_BG_PID=$!
+          echo "MAKE_RUN_BG_PID=${MAKE_RUN_BG_PID}" | tee -a $GITHUB_ENV
 
       - name: Create a Unit Tests session
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
@@ -151,7 +153,10 @@ jobs:
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         # run this stage only if there are changes that match the includes and not the excludes
         # perform it on backstage.io for speed
-        run: make integration-test PROFILE=backstage.io USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true
+        run: |
+          make integration-test PROFILE=backstage.io USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true
+          kill "${{ env.MAKE_RUN_BG_PID }}" || true
+          make uninstall
 
       - name: Create a E2E Tests session
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -124,10 +124,12 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: make lint
 
-      - name: Start Minikube
-        # run this stage only if there are changes that match the includes and not the excludes
+      - name: Create Kind cluster
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: medyagh/setup-minikube@cea33675329b799adccc9526aa5daccc26cd5052 # v0.0.19
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: test-cluster
+          ignore_failed_clean: true
 
       - name: Run Controller
         # run this stage only if there are changes that match the includes and not the excludes

--- a/Makefile
+++ b/Makefile
@@ -187,13 +187,11 @@ endif
 
 .PHONY: test-e2e
 test-e2e: ginkgo ## Run end-to-end tests. See the 'tests/e2e/README.md' file for more details.
-	# go test ./test/e2e/ -v -ginkgo.v
-	$(GINKGO) $(GINKGO_FLAGS) --skip-file=e2e_upgrade_test.go tests/e2e
+	$(GINKGO) $(GINKGO_FLAGS) --flake-attempts=2 --skip-file=e2e_upgrade_test.go tests/e2e
 
 .PHONY: test-e2e-upgrade
 test-e2e-upgrade: ginkgo ## Run end-to-end tests dedicated to the operator upgrade paths. See the 'tests/e2e/README.md' file for more details.
-	# go test ./test/e2e/ -v -ginkgo.v
-	$(GINKGO) $(GINKGO_FLAGS) --focus-file=e2e_upgrade_test.go tests/e2e
+	$(GINKGO) $(GINKGO_FLAGS) --flake-attempts=2 --focus-file=e2e_upgrade_test.go tests/e2e
 
 .PHONY: gosec
 gosec: addgosec ## run the gosec scanner for non-test files in this repo

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ integration-test: ginkgo manifests generate fmt vet envtest $(LOCALBIN) ## Run i
 	LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -v -r $(ARGS) integration_tests
 
 # After this time, Ginkgo will emit progress reports, so we can get visibility into long-running tests.
-POLL_PROGRESS_INTERVAL := 120s
+POLL_PROGRESS_INTERVAL := 600s
 TIMEOUT ?= 14400s
 GINKGO_FLAGS_ALL = $(GINKGO_TEST_ARGS) --randomize-all --poll-progress-after=$(POLL_PROGRESS_INTERVAL) --poll-progress-interval=$(POLL_PROGRESS_INTERVAL) -timeout $(TIMEOUT) --no-color
 # Flags for tests that may be run in parallel

--- a/examples/bs-existing-secret.yaml
+++ b/examples/bs-existing-secret.yaml
@@ -1,13 +1,3 @@
-apiVersion: rhdh.redhat.com/v1alpha3
-kind: Backstage
-metadata:
-  name: bs-existing-secret
-spec:
-  database:
-    enableLocalDb: true
-    authSecretName: existing-postgres-secret
-
----
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,3 +9,13 @@ stringData:
   POSTGRES_USER: "postgres"
   POSTGRESQL_ADMIN_PASSWORD: "admin123"
   POSTGRES_HOST: "backstage-psql-bs-existing-secret"
+
+---
+apiVersion: rhdh.redhat.com/v1alpha3
+kind: Backstage
+metadata:
+  name: bs-existing-secret
+spec:
+  database:
+    enableLocalDb: true
+    authSecretName: existing-postgres-secret

--- a/examples/filemounts.yaml
+++ b/examples/filemounts.yaml
@@ -1,31 +1,3 @@
-apiVersion: rhdh.redhat.com/v1alpha3
-kind: Backstage
-metadata:
-  name: my-rhdh-file-mounts
-spec:
-  application:
-    extraFiles:
-      mountPath: /my/path
-      configMaps:
-        - name: cm1 # /my/path/file11.txt and /my/path/file12.txt expected, watched
-        - name: cm2 # /my/path/file21.txt expected, watched
-          key: file21.txt
-        - name: cm3  # /my/cm3/path/file31.txt and /my/cm3/path/file312.txt expected, not watched
-          mountPath: /my/cm3/path
-        - name: cm4  # /my/cm4/path/file41.txt expected, watched
-          mountPath: /my/cm4/path
-          key: file41.txt
-      secrets:
-        - name: secret1 # /my/path/secret11.txt expected, watched
-          key: secret11.txt
-        - name: secret2 # /my/secret2/path/secret21.txt and /my/secret2/path/secret22.txt expected, not watched
-          mountPath: /my/secret2/path
-        - name: secret3 # /my/secret3/path/secret31.txt expected, watched
-          mountPath: /my/secret3/path
-          key: secret31.txt
-#        - name: secret4  <-- this is forbidden
-
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -101,3 +73,29 @@ stringData:
     base64-encoded-content
 
 ---
+apiVersion: rhdh.redhat.com/v1alpha3
+kind: Backstage
+metadata:
+  name: my-rhdh-file-mounts
+spec:
+  application:
+    extraFiles:
+      mountPath: /my/path
+      configMaps:
+        - name: cm1 # /my/path/file11.txt and /my/path/file12.txt expected, watched
+        - name: cm2 # /my/path/file21.txt expected, watched
+          key: file21.txt
+        - name: cm3  # /my/cm3/path/file31.txt and /my/cm3/path/file312.txt expected, not watched
+          mountPath: /my/cm3/path
+        - name: cm4  # /my/cm4/path/file41.txt expected, watched
+          mountPath: /my/cm4/path
+          key: file41.txt
+      secrets:
+        - name: secret1 # /my/path/secret11.txt expected, watched
+          key: secret11.txt
+        - name: secret2 # /my/secret2/path/secret21.txt and /my/secret2/path/secret22.txt expected, not watched
+          mountPath: /my/secret2/path
+        - name: secret3 # /my/secret3/path/secret31.txt expected, watched
+          mountPath: /my/secret3/path
+          key: secret31.txt
+#        - name: secret4  <-- this is forbidden

--- a/examples/raw-runtime-config.yaml
+++ b/examples/raw-runtime-config.yaml
@@ -1,14 +1,3 @@
-apiVersion: rhdh.redhat.com/v1alpha3
-kind: Backstage
-metadata:
-  name: bs-raw-runtime-config
-spec:
-  rawRuntimeConfig:
-    backstageConfig: raw-runtime-config
-  database:
-    enableLocalDb: false
-
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -64,3 +53,12 @@ stringData:
   MY_SUPER_SECRET_1: "some value" # notsecret
 
 ---
+apiVersion: rhdh.redhat.com/v1alpha3
+kind: Backstage
+metadata:
+  name: bs-raw-runtime-config
+spec:
+  rawRuntimeConfig:
+    backstageConfig: raw-runtime-config
+  database:
+    enableLocalDb: false

--- a/examples/rhdh-cr-with-app-configs.yaml
+++ b/examples/rhdh-cr-with-app-configs.yaml
@@ -1,46 +1,3 @@
-apiVersion: rhdh.redhat.com/v1alpha3
-kind: Backstage
-metadata:
-  name: bs-app-config
-spec:
-  database:
-    enableLocalDb: true
-  deployment:
-    patch:
-      spec:
-        replicas: 2
-  application:
-    appConfig:
-      configMaps:
-        - name: "my-backstage-config-backend-base-urls"
-        - name: "my-backstage-config-backend-auth"
-        - name: "my-backstage-config-cm1"
-        - name: "my-backstage-config-cm2"
-          key: "app-config1-cm2.gh.yaml"
-    dynamicPluginsConfigMapName: "my-dynamic-plugins-config-cm"
-    extraFiles:
-      mountPath: /tmp/my-extra-files
-      configMaps:
-        - name: "my-backstage-extra-files-cm1"
-      secrets:
-        - name: "my-backstage-extra-files-secret1"
-          key: secret_file1.txt
-    extraEnvs:
-      envs:
-        - name: GITHUB_ORG
-          value: 'my-gh-org'
-        - name: MY_ENV_VAR_2
-          value: my-value-2
-      configMaps:
-        - name: my-env-cm-1
-        - name: my-env-cm-11
-          key: CM_ENV11
-      secrets:
-        - name: "my-backstage-backend-auth-secret"
-          key: BACKEND_SECRET
-        - name: my-gh-auth-secret
-
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -239,3 +196,44 @@ stringData:
       SomeRsaPrivateKey
 
 ---
+apiVersion: rhdh.redhat.com/v1alpha3
+kind: Backstage
+metadata:
+  name: bs-app-config
+spec:
+  database:
+    enableLocalDb: true
+  deployment:
+    patch:
+      spec:
+        replicas: 1
+  application:
+    appConfig:
+      configMaps:
+        - name: "my-backstage-config-backend-base-urls"
+        - name: "my-backstage-config-backend-auth"
+        - name: "my-backstage-config-cm1"
+        - name: "my-backstage-config-cm2"
+          key: "app-config1-cm2.gh.yaml"
+    dynamicPluginsConfigMapName: "my-dynamic-plugins-config-cm"
+    extraFiles:
+      mountPath: /tmp/my-extra-files
+      configMaps:
+        - name: "my-backstage-extra-files-cm1"
+      secrets:
+        - name: "my-backstage-extra-files-secret1"
+          key: secret_file1.txt
+    extraEnvs:
+      envs:
+        - name: GITHUB_ORG
+          value: 'my-gh-org'
+        - name: MY_ENV_VAR_2
+          value: my-value-2
+      configMaps:
+        - name: my-env-cm-1
+        - name: my-env-cm-11
+          key: CM_ENV11
+      secrets:
+        - name: "my-backstage-backend-auth-secret"
+          key: BACKEND_SECRET
+        - name: my-gh-auth-secret

--- a/examples/rhdh-cr.yaml
+++ b/examples/rhdh-cr.yaml
@@ -1,26 +1,3 @@
-apiVersion: rhdh.redhat.com/v1alpha3
-kind: Backstage
-metadata:
-  name: my-rhdh
-spec:
-  deployment:
-    patch:
-      spec:
-        template:
-          spec:
-            containers:
-              - name: backstage-backend
-                image: quay.io/rhdh/rhdh-hub-rhel9:latest
-  application:
-    appConfig:
-      configMaps:
-        - name: app-config-rhdh
-    dynamicPluginsConfigMapName: dynamic-plugins-rhdh
-    extraEnvs:
-      secrets:
-        - name: secrets-rhdh
-
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -91,3 +68,24 @@ data:
                     initialDelay: { seconds: 15}
 
 ---
+apiVersion: rhdh.redhat.com/v1alpha3
+kind: Backstage
+metadata:
+  name: my-rhdh
+spec:
+  deployment:
+    patch:
+      spec:
+        template:
+          spec:
+            containers:
+              - name: backstage-backend
+                image: quay.io/rhdh/rhdh-hub-rhel9:latest
+  application:
+    appConfig:
+      configMaps:
+        - name: app-config-rhdh
+    dynamicPluginsConfigMapName: dynamic-plugins-rhdh
+    extraEnvs:
+      secrets:
+        - name: secrets-rhdh

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -213,10 +213,13 @@ func verifyControllerUp(g Gomega, managerPodLabel string) {
 }
 
 func getPodLogs(ns string, label string) string {
-	cmd := exec.Command(helper.GetPlatformTool(), "logs",
-		"-l", label,
-		"-n", ns,
-	)
+	cmd := exec.Command(helper.GetPlatformTool(), "logs", "--all-containers", "-l", label, "-n", ns)
+	output, _ := helper.Run(cmd)
+	return string(output)
+}
+
+func describePod(ns string, label string) string {
+	cmd := exec.Command(helper.GetPlatformTool(), "describe", "pods", "-l", label, "-n", ns)
 	output, _ := helper.Run(cmd)
 	return string(output)
 }
@@ -241,10 +244,16 @@ func fetchOperandLogs(ns string, crLabel string, raw bool) func() string {
 	}
 }
 
-func fetchOperatorAndOperandLogs(managerPodLabel string, ns string, crLabel string) func() string {
-	return func() string {
-		return fmt.Sprintf("%s\n\n%s\n", fetchOperatorLogs(managerPodLabel, false)(), fetchOperandLogs(ns, crLabel, false)())
-	}
+func fetchOperatorAndOperandLogs(managerPodLabel string, ns string, crLabel string) string {
+	return fmt.Sprintf("%s\n\n%s\n",
+		fetchOperatorLogs(managerPodLabel, false)(),
+		fetchOperandLogs(ns, crLabel, false)())
+}
+
+func describeOperatorAndOperatorPods(managerPodLabel string, ns string, crLabel string) string {
+	return fmt.Sprintf("%s\n\n%s\n",
+		describePod(_namespace, managerPodLabel),
+		describePod(ns, crLabel))
 }
 
 func uninstallOperator() {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -120,13 +120,23 @@ var _ = Describe("Backstage Operator E2E", func() {
 						// [{"lastTransitionTime":"2025-04-09T09:02:06Z","message":"","reason":"Deployed","status":"True","type":"Deployed"}]
 						Eventually(helper.VerifyBackstageCRStatus, time.Minute, 10*time.Second).
 							WithArguments(ns, tt.crName, ContainSubstring(`"type":"Deployed"`)).
-							Should(Succeed(), fetchOperatorAndOperandLogs(managerPodLabel, ns, crLabel))
+							Should(Succeed(), func() string {
+								return fmt.Sprintf("%s\n---\n%s",
+									fetchOperatorAndOperandLogs(managerPodLabel, ns, crLabel),
+									describeOperatorAndOperatorPods(managerPodLabel, ns, crLabel),
+								)
+							})
 					})
 
 					By("validating that pod(s) status.phase=Running", func() {
 						Eventually(helper.VerifyBackstagePodStatus, 10*time.Minute, 10*time.Second).
 							WithArguments(ns, tt.crName, "Running").
-							Should(Succeed(), fetchOperatorAndOperandLogs(managerPodLabel, ns, crLabel))
+							Should(Succeed(), func() string {
+								return fmt.Sprintf("%s\n---\n%s",
+									fetchOperatorAndOperandLogs(managerPodLabel, ns, crLabel),
+									describeOperatorAndOperatorPods(managerPodLabel, ns, crLabel),
+								)
+							})
 					})
 
 					if helper.IsOpenShift() {
@@ -138,7 +148,12 @@ var _ = Describe("Backstage Operator E2E", func() {
 									g.Expect(exists).Should(BeTrue())
 								}, 15*time.Second, time.Second).
 									WithArguments(tt.crName).
-									ShouldNot(Succeed(), fetchOperatorAndOperandLogs(managerPodLabel, ns, crLabel))
+									ShouldNot(Succeed(), func() string {
+										return fmt.Sprintf("%s\n---\n%s",
+											fetchOperatorAndOperandLogs(managerPodLabel, ns, crLabel),
+											describeOperatorAndOperatorPods(managerPodLabel, ns, crLabel),
+										)
+									})
 							})
 						} else {
 							By("ensuring the route is reachable", func() {
@@ -251,5 +266,10 @@ spec:
 func ensureRouteIsReachable(ns string, crName string, crLabel string, additionalApiEndpointTests []helper.ApiEndpointTest) {
 	Eventually(helper.VerifyBackstageRoute, 5*time.Minute, time.Second).
 		WithArguments(ns, crName, additionalApiEndpointTests).
-		Should(Succeed(), fetchOperatorAndOperandLogs(managerPodLabel, ns, crLabel))
+		Should(Succeed(), func() string {
+			return fmt.Sprintf("%s\n---\n%s",
+				fetchOperatorAndOperandLogs(managerPodLabel, ns, crLabel),
+				describeOperatorAndOperatorPods(managerPodLabel, ns, crLabel),
+			)
+		})
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/onsi/gomega/gcustom"
+	"github.com/tidwall/gjson"
 
 	"github.com/redhat-developer/rhdh-operator/tests/helper"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tidwall/gjson"
 )
 
 var _ = Describe("Backstage Operator E2E", func() {
@@ -44,6 +44,7 @@ var _ = Describe("Backstage Operator E2E", func() {
 			name                       string
 			crFilePath                 string
 			crName                     string
+			isForOpenshift             bool
 			isRouteDisabled            bool
 			additionalApiEndpointTests []helper.ApiEndpointTest
 		}{
@@ -53,15 +54,17 @@ var _ = Describe("Backstage Operator E2E", func() {
 				crName:     "bs1",
 			},
 			{
-				name:       "specific route sub-domain",
-				crFilePath: filepath.Join("examples", "bs-route.yaml"),
-				crName:     "bs-route",
+				name:           "specific route sub-domain",
+				crFilePath:     filepath.Join("examples", "bs-route.yaml"),
+				crName:         "bs-route",
+				isForOpenshift: true,
 			},
 			{
 				name:            "route disabled",
 				crFilePath:      filepath.Join("examples", "bs-route-disabled.yaml"),
 				crName:          "bs-route-disabled",
 				isRouteDisabled: true,
+				isForOpenshift:  true,
 			},
 			{
 				name:       "RHDH CR with app-configs, dynamic plugins, extra files and extra-envs",
@@ -102,6 +105,9 @@ var _ = Describe("Backstage Operator E2E", func() {
 				var crPath string
 				var crLabel string
 				BeforeEach(func() {
+					if tt.isForOpenshift && !helper.IsOpenShift() {
+						Skip("Skipping OpenShift-only test on non OCP platform")
+					}
 					crPath = filepath.Join(projectDir, tt.crFilePath)
 					cmd := exec.Command(helper.GetPlatformTool(), "apply", "-f", crPath, "-n", ns)
 					_, err := helper.Run(cmd)

--- a/tests/e2e/testdata/rhdh-operator-1.5.yaml
+++ b/tests/e2e/testdata/rhdh-operator-1.5.yaml
@@ -1979,7 +1979,7 @@ spec:
           value: quay.io/fedora/postgresql-15:latest
         - name: RELATED_IMAGE_backstage
           value: quay.io/rhdh/rhdh-hub-rhel9:1.5
-        image: quay.io/rhdh-community/operator:0.5.2
+        image: quay.io/rhdh-community/operator:0.5.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/tests/helper/helper_backstage.go
+++ b/tests/helper/helper_backstage.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -177,6 +178,14 @@ func VerifyBackstageRoute(g Gomega, ns string, crName string, tests []ApiEndpoin
 	g.Expect(host).ShouldNot(BeEmpty())
 
 	VerifyBackstageAppAccess(g, fmt.Sprintf("https://%s", host), tests)
+}
+
+func VerifyBackstageAppAccessWithUrlProvider(g Gomega, baseUrlProvider func(g Gomega) (context.CancelFunc, string), tests []ApiEndpointTest) {
+	cancelFunc, appUrl := baseUrlProvider(g)
+	if cancelFunc != nil {
+		defer cancelFunc()
+	}
+	VerifyBackstageAppAccess(g, appUrl, tests)
 }
 
 func VerifyBackstageAppAccess(g Gomega, baseUrl string, tests []ApiEndpointTest) {


### PR DESCRIPTION
## Description

This attempts to fix the nightly tests that have been failing for quite some time. I've narrowed it down to some flakiness in the Minikube action when the ingress add-on is enabled.
To alleviate this, this PR switches to a Kind cluster instead (similar to what is done in the [rhdh-chart repo](https://github.com/redhat-developer/rhdh-chart/blob/main/.github/workflows/test.yaml#L70-L91)).

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-7804

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer

Examples of runs:
- https://github.com/rm3l/redhat-developer-hub-operator/actions/runs/15584248268
- https://github.com/rm3l/redhat-developer-hub-operator/actions/runs/15584273681/job/43886544000

`make test-e2e` should pass on both OCP and vanilla K8s.