### PR TITLE
ci(nightly): Apply the resources as the tests might be rerun to account for potential flakiness [RHIDP-7804]

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Backstage Operator E2E", func() {
 							}
 							appUrl := fmt.Sprintf("%s.%s", tt.crName, ingressDomain)
 							By("manually creating a K8s Ingress", func() {
-								cmd := exec.Command(helper.GetPlatformTool(), "-n", ns, "create", "-f", "-")
+								cmd := exec.Command(helper.GetPlatformTool(), "-n", ns, "apply", "-f", "-")
 								stdin, err := cmd.StdinPipe()
 								ExpectWithOffset(1, err).NotTo(HaveOccurred())
 								go func() {

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Operator upgrade with existing instances", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			EventuallyWithOffset(1, verifyControllerUp, 5*time.Minute, time.Second).WithArguments("app=rhdh-operator").Should(Succeed())
 
-			cmd = exec.Command(helper.GetPlatformTool(), "-n", ns, "create", "-f", "-")
+			cmd = exec.Command(helper.GetPlatformTool(), "-n", ns, "apply", "-f", "-")
 			stdin, err := cmd.StdinPipe()
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 			go func() {


### PR DESCRIPTION
## Description
Follow-up to https://github.com/redhat-developer/rhdh-operator/pull/1257. Run `{oc|kubectl} apply" instead, as the test might be rerun.

## Which issue(s) does this PR fix or relate to

- Relates to https://issues.redhat.com/browse/RHIDP-7804

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
