### PR TITLE
fix: remove default replicas value to support HPA scaling

### DIFF
--- a/bundle/backstage.io/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/backstage.io/manifests/backstage-default-config_v1_configmap.yaml
@@ -55,7 +55,7 @@ data:
       name: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
     spec:
       podManagementPolicy: OrderedReady
-      replicas: 1
+      # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
       selector:
         matchLabels:
           rhdh.redhat.com/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-06-19T14:03:51Z"
+    createdAt: "2025-06-19T16:00:09Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-05-21T20:27:26Z"
+    createdAt: "2025-06-19T02:50:22Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-06-19T02:50:22Z"
+    createdAt: "2025-06-19T14:03:51Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
-    createdAt: "2025-06-19T14:03:50Z"
+    createdAt: "2025-06-19T16:00:08Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
-    createdAt: "2025-05-21T20:27:25Z"
+    createdAt: "2025-06-19T02:50:20Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
-    createdAt: "2025-06-19T02:50:20Z"
+    createdAt: "2025-06-19T14:03:50Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -58,7 +58,7 @@ data:
       name: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
     spec:
       podManagementPolicy: OrderedReady
-      replicas: 1
+      # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
       selector:
         matchLabels:
           rhdh.redhat.com/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
@@ -179,6 +179,7 @@ data:
     metadata:
       name: backstage # placeholder for 'backstage-<cr-name>'
     spec:
+      # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
       selector:
         matchLabels:
           rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -179,7 +179,6 @@ data:
     metadata:
       name: backstage # placeholder for 'backstage-<cr-name>'
     spec:
-      replicas: 1
       selector:
         matchLabels:
           rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'

--- a/config/profile/backstage.io/default-config/db-statefulset.yaml
+++ b/config/profile/backstage.io/default-config/db-statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
 spec:
   podManagementPolicy: OrderedReady
-  replicas: 1
+  # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
   selector:
     matchLabels:
       rhdh.redhat.com/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'

--- a/config/profile/rhdh/default-config/db-statefulset.yaml
+++ b/config/profile/rhdh/default-config/db-statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
 spec:
   podManagementPolicy: OrderedReady
-  replicas: 1
+  # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
   selector:
     matchLabels:
       rhdh.redhat.com/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'

--- a/config/profile/rhdh/default-config/deployment.yaml
+++ b/config/profile/rhdh/default-config/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: backstage # placeholder for 'backstage-<cr-name>'
 spec:
+  # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
   selector:
     matchLabels:
       rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'

--- a/config/profile/rhdh/default-config/deployment.yaml
+++ b/config/profile/rhdh/default-config/deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: backstage # placeholder for 'backstage-<cr-name>'
 spec:
-  replicas: 1
   selector:
     matchLabels:
       rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'

--- a/dist/backstage.io/install.yaml
+++ b/dist/backstage.io/install.yaml
@@ -1566,7 +1566,7 @@ data:
       name: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
     spec:
       podManagementPolicy: OrderedReady
-      replicas: 1
+      # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
       selector:
         matchLabels:
           rhdh.redhat.com/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -1632,7 +1632,7 @@ data:
       name: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
     spec:
       podManagementPolicy: OrderedReady
-      replicas: 1
+      # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
       selector:
         matchLabels:
           rhdh.redhat.com/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
@@ -1753,6 +1753,7 @@ data:
     metadata:
       name: backstage # placeholder for 'backstage-<cr-name>'
     spec:
+      # replicas: 1 # Intentionally omitted to allow HPA or custom scaling control.
       selector:
         matchLabels:
           rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -1753,7 +1753,6 @@ data:
     metadata:
       name: backstage # placeholder for 'backstage-<cr-name>'
     spec:
-      replicas: 1
       selector:
         matchLabels:
           rhdh.redhat.com/app: # placeholder for 'backstage-<cr-name>'


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
This PR emoves the `replicas: 1` field from `config/profile/rhdh/default-config/deployment.yaml`.

This change allows users to apply Horizontal Pod Autoscalers (HPA) to the Backstage deployment without the operator reverting replica counts.

- Verified locally on Kind with metrics-server
- Confirmed HPA scales to 3 under CPU load
- Operator no longer resets to 1

You can view my entire replication of the issue and overall steps I took to ensure the fix works, in the issue comments section: https://issues.redhat.com/browse/RHIDP-7857

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-7857 

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
