### PR TITLE
chore(deps): Revert "chore(deps): update redhat-plumbers-in-action/differential-shellcheck digest to 929381c (#1206)"

### DIFF
--- a/.github/workflows/scripts-checks.yaml
+++ b/.github/workflows/scripts-checks.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - id: ShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@929381c602ed76daa9b523e001ee29b82bd6d8e9 # v5
+        uses: redhat-plumbers-in-action/differential-shellcheck@dd551ce780d8af741f8cd8bab6982667b906b457 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description
For some reason, this dependency update is supposed to have fixed some
alerts that were displayed in Code Scanning. But these alerts seem to be
still relevant. So reverting so that the alerts can be reopened and so
that we can work on fixing those alerts (at least the most critical
ones).

This reverts commit 91f5b2c3f34be000c43be5088097296b073d3778.

## Which issue(s) does this PR fix or relate to

Relates to https://issues.redhat.com/browse/RHIDP-6780

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
