### PR TITLE
Remove unused permission for knative in RBAC

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-06-19T16:00:09Z"
+    createdAt: "2025-07-01T09:18:38Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
-    createdAt: "2025-06-19T16:00:08Z"
+    createdAt: "2025-07-01T09:18:37Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed
@@ -216,19 +216,6 @@ spec:
           - networking.k8s.io
           resources:
           - networkpolicies
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - operator.knative.dev
-          resources:
-          - knativeeventings
-          - knativeservings
           verbs:
           - create
           - delete

--- a/config/profile/rhdh/plugin-rbac/rbac-sonataflow.yaml
+++ b/config/profile/rhdh/plugin-rbac/rbac-sonataflow.yaml
@@ -28,19 +28,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - "operator.knative.dev"
-    resources:
-      - knativeeventings
-      - knativeservings
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -1437,19 +1437,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - operator.knative.dev
-  resources:
-  - knativeeventings
-  - knativeservings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Remove unused RBAC permissions for Knative resources

## Which issue(s) does this PR fix or relate to

- relates to PR: https://github.com/redhat-developer/rhdh-operator/pull/1219

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## Summary by Sourcery

Enhancements:
- Remove unused ClusterRole rules for operator.knative.dev resources (knativeeventings and knativeservings) and their verbs.