### PR TITLE
Orchestrator Plugin Infra Update

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-07-01T09:23:20Z"
+    createdAt: "2025-07-02T07:33:18Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
-    createdAt: "2025-07-01T09:23:22Z"
+    createdAt: "2025-07-02T07:33:16Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -343,72 +343,40 @@ data:
           securityContext:
             # any group id
             fsGroup: 1001
-  dynamic-plugins.yaml: |
-    #apiVersion: v1
-    #kind: ConfigMap
-    #metadata:
-    #  name: default-dynamic-plugins #  must be the same as (deployment.yaml).spec.template.spec.volumes.name.dynamic-plugins-conf.configMap.name
-    #data:
-    #  "dynamic-plugins.yaml": |
-    #    ###########################################################################################################
-    #    # /!\ WARNING
-    #    #
-    #    # This is the default dynamic plugins configuration file created and managed by the Operator for your CR.
-    #    # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
-    #    # next reconciliation.
-    #    # If you want to customize the dynamic plugins, you should create your own dynamic-plugins ConfigMap
-    #    # and reference it in your CR.
-    #    # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-installing-rhdh-plugins_title-plugins-rhdh-about#proc-config-dynamic-plugins-rhdh-operator_rhdh-installing-rhdh-plugins
-    #    # for more details or https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml
-    #    # for an example.
-    #    ###########################################################################################################
-    #    includes:
-    #      - dynamic-plugins.default.yaml
-    #    plugins: []
-    #---
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: default-dynamic-plugins
-    data:
-      dynamic-plugins.yaml: |
-        includes:
-          - dynamic-plugins.default.yaml
-        plugins:
-          - disabled: true
-            package: "@redhat/backstage-plugin-orchestrator@1.5.1"
-            integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
-            pluginConfig:
-              dynamicPlugins:
-                  frontend:
-                    red-hat-developer-hub.backstage-plugin-orchestrator:
-                      appIcons:
-                        - importName: OrchestratorIcon
-                          module: OrchestratorPlugin
-                          name: orchestratorIcon
-                      dynamicRoutes:
-                        - importName: OrchestratorPage
-                          menuItem:
-                            icon: orchestratorIcon
-                            text: Orchestrator
-                          module: OrchestratorPlugin
-                          path: /orchestrator
-          - disabled: true
-            package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1"
-            integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
-            pluginConfig:
-              orchestrator:
-                dataIndexService:
-                  url: http://sonataflow-platform-data-index-service
-            dependencies:
-              - ref: sonataflow
-          - disabled: true
-            package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1"
-            integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
-            pluginConfig:
-              orchestrator:
-                dataIndexService:
-                  url: http://sonataflow-platform-data-index-service
+  dynamic-plugins.yaml: "#apiVersion: v1\n#kind: ConfigMap\n#metadata:\n#  name: default-dynamic-plugins
+    #  must be the same as (deployment.yaml).spec.template.spec.volumes.name.dynamic-plugins-conf.configMap.name\n#data:\n#
+    \ \"dynamic-plugins.yaml\": |\n#    ###########################################################################################################\n#
+    \   # /!\\ WARNING\n#    #\n#    # This is the default dynamic plugins configuration
+    file created and managed by the Operator for your CR.\n#    # Do NOT edit this
+    manually in the Cluster, as your changes will be overridden by the Operator upon
+    the\n#    # next reconciliation.\n#    # If you want to customize the dynamic
+    plugins, you should create your own dynamic-plugins ConfigMap\n#    # and reference
+    it in your CR.\n#    # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-installing-rhdh-plugins_title-plugins-rhdh-about#proc-config-dynamic-plugins-rhdh-operator_rhdh-installing-rhdh-plugins\n#
+    \   # for more details or https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml\n#
+    \   # for an example.\n#    ###########################################################################################################\n#
+    \   includes:\n#      - dynamic-plugins.default.yaml\n#    plugins: []\n#---\napiVersion:
+    v1\nkind: ConfigMap\nmetadata:\n  name: default-dynamic-plugins\ndata:\n  dynamic-plugins.yaml:
+    |\n    includes:\n      - dynamic-plugins.default.yaml\n    plugins:\n      -
+    disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator@1.6.0\"\n
+    \       integrity: sha512-fOSJv2PgtD2urKwBM7p9W6gV/0UIHSf4pkZ9V/wQO0eg0Zi5Mys/CL1ba3nO9x9l84MX11UBZ2r7PPVJPrmOtw==\n
+    \       pluginConfig:\n          dynamicPlugins:\n              frontend:\n                red-hat-developer-hub.backstage-plugin-orchestrator:\n
+    \                 appIcons:\n                    - importName: OrchestratorIcon\n
+    \                     name: orchestratorIcon\n                  dynamicRoutes:\n
+    \                   - importName: OrchestratorPage\n                      menuItem:\n
+    \                       icon: orchestratorIcon\n                        text:
+    Orchestrator\n                      path: /orchestrator\n      - disabled: true\n
+    \       package: \"@redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.0\"\n
+    \       integrity: sha512-Kr55YbuVwEADwGef9o9wyimcgHmiwehPeAtVHa9g2RQYoSPEa6BeOlaPzB6W5Ke3M2bN/0j0XXtpLuvrlXQogA==\n
+    \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
+    \             url: http://sonataflow-platform-data-index-service\n        dependencies:\n
+    \         - ref: sonataflow\n      - disabled: true\n        package: \"@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.0\"\n
+    \       integrity: sha512-Bueeix4661fXEnfJ9y31Yw91LXJgw6hJUG7lPVdESCi9VwBCjDB9Rm8u2yPqP8sriwr0OMtKtqD+Odn3LOPyVw==\n
+    \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
+    \             url: http://sonataflow-platform-data-index-service               \n
+    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-form-widgets@1.6.0\"\n
+    \       integrity: sha512-Tqn6HO21Q1TQ7TFUoRhwBVCtSBzbQYz+OaanzzIB0R24O6YtVx3wR7Chtr5TzC05Vz5GkBO1+FZid8BKpqljgA==\n
+    \       pluginConfig:\n          dynamicPlugins:\n            frontend:\n              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets:
+    { }"
   route.yaml: |-
     apiVersion: route.openshift.io/v1
     kind: Route

--- a/config/profile/rhdh/default-config/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/dynamic-plugins.yaml
@@ -30,25 +30,23 @@ data:
       - dynamic-plugins.default.yaml
     plugins:
       - disabled: true
-        package: "@redhat/backstage-plugin-orchestrator@1.5.1"
-        integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
+        package: "@redhat/backstage-plugin-orchestrator@1.6.0"
+        integrity: sha512-fOSJv2PgtD2urKwBM7p9W6gV/0UIHSf4pkZ9V/wQO0eg0Zi5Mys/CL1ba3nO9x9l84MX11UBZ2r7PPVJPrmOtw==
         pluginConfig:
           dynamicPlugins:
               frontend:
                 red-hat-developer-hub.backstage-plugin-orchestrator:
                   appIcons:
                     - importName: OrchestratorIcon
-                      module: OrchestratorPlugin
                       name: orchestratorIcon
                   dynamicRoutes:
                     - importName: OrchestratorPage
                       menuItem:
                         icon: orchestratorIcon
                         text: Orchestrator
-                      module: OrchestratorPlugin
                       path: /orchestrator
       - disabled: true
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1"
+        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.0"
         integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
         pluginConfig:
           orchestrator:
@@ -57,9 +55,16 @@ data:
         dependencies:
           - ref: sonataflow
       - disabled: true
-        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1"
-        integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
+        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.0"
+        integrity: sha512-Bueeix4661fXEnfJ9y31Yw91LXJgw6hJUG7lPVdESCi9VwBCjDB9Rm8u2yPqP8sriwr0OMtKtqD+Odn3LOPyVw==
         pluginConfig:
           orchestrator:
             dataIndexService:
-              url: http://sonataflow-platform-data-index-service
+              url: http://sonataflow-platform-data-index-service               
+      - disabled: false
+        package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.6.0"
+        integrity: sha512-Tqn6HO21Q1TQ7TFUoRhwBVCtSBzbQYz+OaanzzIB0R24O6YtVx3wR7Chtr5TzC05Vz5GkBO1+FZid8BKpqljgA==
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: { }

--- a/config/profile/rhdh/default-config/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/dynamic-plugins.yaml
@@ -47,7 +47,7 @@ data:
                       path: /orchestrator
       - disabled: true
         package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.0"
-        integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
+        integrity: sha512-Kr55YbuVwEADwGef9o9wyimcgHmiwehPeAtVHa9g2RQYoSPEa6BeOlaPzB6W5Ke3M2bN/0j0XXtpLuvrlXQogA==
         pluginConfig:
           orchestrator:
             dataIndexService:
@@ -61,7 +61,7 @@ data:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service               
-      - disabled: false
+      - disabled: true
         package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.6.0"
         integrity: sha512-Tqn6HO21Q1TQ7TFUoRhwBVCtSBzbQYz+OaanzzIB0R24O6YtVx3wR7Chtr5TzC05Vz5GkBO1+FZid8BKpqljgA==
         pluginConfig:

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -1904,72 +1904,40 @@ data:
           securityContext:
             # any group id
             fsGroup: 1001
-  dynamic-plugins.yaml: |
-    #apiVersion: v1
-    #kind: ConfigMap
-    #metadata:
-    #  name: default-dynamic-plugins #  must be the same as (deployment.yaml).spec.template.spec.volumes.name.dynamic-plugins-conf.configMap.name
-    #data:
-    #  "dynamic-plugins.yaml": |
-    #    ###########################################################################################################
-    #    # /!\ WARNING
-    #    #
-    #    # This is the default dynamic plugins configuration file created and managed by the Operator for your CR.
-    #    # Do NOT edit this manually in the Cluster, as your changes will be overridden by the Operator upon the
-    #    # next reconciliation.
-    #    # If you want to customize the dynamic plugins, you should create your own dynamic-plugins ConfigMap
-    #    # and reference it in your CR.
-    #    # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-installing-rhdh-plugins_title-plugins-rhdh-about#proc-config-dynamic-plugins-rhdh-operator_rhdh-installing-rhdh-plugins
-    #    # for more details or https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml
-    #    # for an example.
-    #    ###########################################################################################################
-    #    includes:
-    #      - dynamic-plugins.default.yaml
-    #    plugins: []
-    #---
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: default-dynamic-plugins
-    data:
-      dynamic-plugins.yaml: |
-        includes:
-          - dynamic-plugins.default.yaml
-        plugins:
-          - disabled: true
-            package: "@redhat/backstage-plugin-orchestrator@1.5.1"
-            integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
-            pluginConfig:
-              dynamicPlugins:
-                  frontend:
-                    red-hat-developer-hub.backstage-plugin-orchestrator:
-                      appIcons:
-                        - importName: OrchestratorIcon
-                          module: OrchestratorPlugin
-                          name: orchestratorIcon
-                      dynamicRoutes:
-                        - importName: OrchestratorPage
-                          menuItem:
-                            icon: orchestratorIcon
-                            text: Orchestrator
-                          module: OrchestratorPlugin
-                          path: /orchestrator
-          - disabled: true
-            package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1"
-            integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
-            pluginConfig:
-              orchestrator:
-                dataIndexService:
-                  url: http://sonataflow-platform-data-index-service
-            dependencies:
-              - ref: sonataflow
-          - disabled: true
-            package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1"
-            integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
-            pluginConfig:
-              orchestrator:
-                dataIndexService:
-                  url: http://sonataflow-platform-data-index-service
+  dynamic-plugins.yaml: "#apiVersion: v1\n#kind: ConfigMap\n#metadata:\n#  name: default-dynamic-plugins
+    #  must be the same as (deployment.yaml).spec.template.spec.volumes.name.dynamic-plugins-conf.configMap.name\n#data:\n#
+    \ \"dynamic-plugins.yaml\": |\n#    ###########################################################################################################\n#
+    \   # /!\\ WARNING\n#    #\n#    # This is the default dynamic plugins configuration
+    file created and managed by the Operator for your CR.\n#    # Do NOT edit this
+    manually in the Cluster, as your changes will be overridden by the Operator upon
+    the\n#    # next reconciliation.\n#    # If you want to customize the dynamic
+    plugins, you should create your own dynamic-plugins ConfigMap\n#    # and reference
+    it in your CR.\n#    # See https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-installing-rhdh-plugins_title-plugins-rhdh-about#proc-config-dynamic-plugins-rhdh-operator_rhdh-installing-rhdh-plugins\n#
+    \   # for more details or https://github.com/redhat-developer/rhdh-operator/blob/main/examples/rhdh-cr.yaml\n#
+    \   # for an example.\n#    ###########################################################################################################\n#
+    \   includes:\n#      - dynamic-plugins.default.yaml\n#    plugins: []\n#---\napiVersion:
+    v1\nkind: ConfigMap\nmetadata:\n  name: default-dynamic-plugins\ndata:\n  dynamic-plugins.yaml:
+    |\n    includes:\n      - dynamic-plugins.default.yaml\n    plugins:\n      -
+    disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator@1.6.0\"\n
+    \       integrity: sha512-fOSJv2PgtD2urKwBM7p9W6gV/0UIHSf4pkZ9V/wQO0eg0Zi5Mys/CL1ba3nO9x9l84MX11UBZ2r7PPVJPrmOtw==\n
+    \       pluginConfig:\n          dynamicPlugins:\n              frontend:\n                red-hat-developer-hub.backstage-plugin-orchestrator:\n
+    \                 appIcons:\n                    - importName: OrchestratorIcon\n
+    \                     name: orchestratorIcon\n                  dynamicRoutes:\n
+    \                   - importName: OrchestratorPage\n                      menuItem:\n
+    \                       icon: orchestratorIcon\n                        text:
+    Orchestrator\n                      path: /orchestrator\n      - disabled: true\n
+    \       package: \"@redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.0\"\n
+    \       integrity: sha512-Kr55YbuVwEADwGef9o9wyimcgHmiwehPeAtVHa9g2RQYoSPEa6BeOlaPzB6W5Ke3M2bN/0j0XXtpLuvrlXQogA==\n
+    \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
+    \             url: http://sonataflow-platform-data-index-service\n        dependencies:\n
+    \         - ref: sonataflow\n      - disabled: true\n        package: \"@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.0\"\n
+    \       integrity: sha512-Bueeix4661fXEnfJ9y31Yw91LXJgw6hJUG7lPVdESCi9VwBCjDB9Rm8u2yPqP8sriwr0OMtKtqD+Odn3LOPyVw==\n
+    \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
+    \             url: http://sonataflow-platform-data-index-service               \n
+    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-form-widgets@1.6.0\"\n
+    \       integrity: sha512-Tqn6HO21Q1TQ7TFUoRhwBVCtSBzbQYz+OaanzzIB0R24O6YtVx3wR7Chtr5TzC05Vz5GkBO1+FZid8BKpqljgA==\n
+    \       pluginConfig:\n          dynamicPlugins:\n            frontend:\n              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets:
+    { }"
   route.yaml: |-
     apiVersion: route.openshift.io/v1
     kind: Route


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
With the recent release of Orchestrator 1.6.0, this PR updates the Orchestrator plugins to 1.6.0 version.

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## Summary by Sourcery

Update orchestrator plugin infrastructure to Orchestrator v1.6.0.

New Features:
- Enable new orchestrator-form-widgets plugin v1.6.0 by default

Enhancements:
- Bump frontend, backend, and scaffolder Orchestrator plugins to v1.6.0