### PR TITLE
Add plugin dependencies integration tests

### DIFF
--- a/integration_tests/plugin-deps_test.go
+++ b/integration_tests/plugin-deps_test.go
@@ -33,6 +33,7 @@ var _ = When("test plugin deps", func() {
 
 	AfterEach(func() {
 		deleteNamespace(ctx, ns)
+		_ = os.Unsetenv("PLUGIN_DEPS_DIR_backstage")
 	})
 
 	It("creates plugin dependencies", func() {

--- a/integration_tests/plugin-deps_test.go
+++ b/integration_tests/plugin-deps_test.go
@@ -1,0 +1,80 @@
+package integration_tests
+
+import (
+	"context"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/redhat-developer/rhdh-operator/pkg/model"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	bsv1 "github.com/redhat-developer/rhdh-operator/api/v1alpha3"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = When("test plugin deps", func() {
+
+	var (
+		ctx context.Context
+		ns  string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ns = createNamespace(ctx)
+	})
+
+	AfterEach(func() {
+		deleteNamespace(ctx, ns)
+	})
+
+	It("creates plugin dependencies", func() {
+
+		err := os.Setenv("PLUGIN_DEPS_DIR_backstage", "testdata/plugin-deps1")
+		Expect(err).NotTo(HaveOccurred())
+
+		dynapluginCm := map[string]string{"dynamic-plugins.yaml": readTestYamlFile("raw-dynaplugins-with-deps.yaml")}
+
+		bsRaw := generateConfigMap(ctx, k8sClient, "dynaplugins", ns, dynapluginCm, nil, nil)
+
+		backstageName := createAndReconcileBackstage(ctx, ns, bsv1.BackstageSpec{
+			RawRuntimeConfig: &bsv1.RuntimeConfig{
+				BackstageConfigName: bsRaw,
+			},
+		}, "")
+
+		Eventually(func(g Gomega) {
+
+			deploy := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: model.DeploymentName(backstageName)}, deploy)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			cm := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "test-dependency"}, cm)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			sec := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "test-dependency2"}, sec)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			// disabled
+			cm = &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "test-dependency3"}, cm)
+			g.Expect(err).Should(HaveOccurred())
+
+			// not listed
+			cm = &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "test-dependency4"}, cm)
+			g.Expect(err).Should(HaveOccurred())
+
+		}, time.Minute, time.Second).Should(Succeed())
+
+	})
+})

--- a/integration_tests/plugin-deps_test.go
+++ b/integration_tests/plugin-deps_test.go
@@ -37,6 +37,13 @@ var _ = When("test plugin deps", func() {
 	})
 
 	It("creates plugin dependencies", func() {
+		if !isProfile("rhdh") {
+			Skip("Skipped for non rhdh config")
+		}
+
+		if useExistingController {
+			Skip("Skipped for real controller")
+		}
 
 		err := os.Setenv("PLUGIN_DEPS_DIR_backstage", "testdata/plugin-deps1")
 		Expect(err).NotTo(HaveOccurred())

--- a/integration_tests/plugin-deps_test.go
+++ b/integration_tests/plugin-deps_test.go
@@ -75,7 +75,7 @@ var _ = When("test plugin deps", func() {
 			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "test-dependency4"}, cm)
 			g.Expect(err).Should(HaveOccurred())
 
-		}, time.Minute, time.Second).Should(Succeed())
+		}, 5*time.Minute, time.Second).Should(Succeed())
 
 	})
 })

--- a/integration_tests/testdata/plugin-deps1/disabled-dep.yaml
+++ b/integration_tests/testdata/plugin-deps1/disabled-dep.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-dependency3

--- a/integration_tests/testdata/plugin-deps1/not-listed-dep.yaml
+++ b/integration_tests/testdata/plugin-deps1/not-listed-dep.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-dependency4

--- a/integration_tests/testdata/plugin-deps1/plugin-dep.yaml
+++ b/integration_tests/testdata/plugin-deps1/plugin-dep.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-dependency
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-dependency2

--- a/integration_tests/testdata/raw-dynaplugins-with-deps.yaml
+++ b/integration_tests/testdata/raw-dynaplugins-with-deps.yaml
@@ -6,10 +6,10 @@ data:
   dynamic-plugins.yaml: |
     plugins:
       - disabled: false
-        package: "plugin"
+        package: "./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page"
         dependencies:
           - ref: plugin
       - disabled: true
         package: "disabled"
         dependencies:
-          - ref: disabled      
+          - ref: disabled

--- a/integration_tests/testdata/raw-dynaplugins-with-deps.yaml
+++ b/integration_tests/testdata/raw-dynaplugins-with-deps.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-dynamic-plugins
+data:
+  dynamic-plugins.yaml: |
+    plugins:
+      - disabled: false
+        package: "plugin"
+        dependencies:
+          - ref: plugin
+      - disabled: true
+        package: "disabled"
+        dependencies:
+          - ref: disabled      

--- a/pkg/model/plugin_deps.go
+++ b/pkg/model/plugin_deps.go
@@ -16,7 +16,12 @@ import (
 )
 
 func GetPluginDeps(backstage bs.Backstage, plugins DynamicPlugins, scheme *runtime.Scheme) ([]*unstructured.Unstructured, error) {
-	dir := filepath.Join(os.Getenv("LOCALBIN"), "plugin-deps")
+
+	dir, ok := os.LookupEnv("PLUGIN_DEPS_DIR_backstage")
+	if !ok {
+		dir = filepath.Join(os.Getenv("LOCALBIN"), "plugin-deps")
+	}
+
 	pdeps, err := plugins.Dependencies()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get plugin dependencies: %w", err)


### PR DESCRIPTION
## Description

Add plugin dependencies integration tests

## Which issue(s) does this PR fix or relate to

https://issues.redhat.com/browse/RHIDP-7069

## PR acceptance criteria

- [x] Tests

## How to test changes / Special notes to the reviewer
make test

## Summary by Sourcery

Add integration tests for plugin dependencies and support custom dependencies directory via an environment variable

Enhancements:
- Allow overriding the plugin dependencies directory using the PLUGIN_DEPS_DIR_backstage environment variable

Tests:
- Add a Ginkgo-based integration test to validate creation of ConfigMaps and Secrets for plugin dependencies based on dynamic plugin configuration
- Provide testdata fixtures for dynamic-plugins.yaml and plugin dependency manifests