### PR TITLE
Update Orchestrator plugins to OCI images.

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-07-08T17:19:41Z"
+    createdAt: "2025-07-09T08:36:43Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-07-02T07:33:18Z"
+    createdAt: "2025-07-08T17:19:41Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
-    createdAt: "2025-07-02T07:33:16Z"
+    createdAt: "2025-07-08T17:19:40Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
-    createdAt: "2025-07-08T17:19:40Z"
+    createdAt: "2025-07-09T08:36:41Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -357,24 +357,20 @@ data:
     \   includes:\n#      - dynamic-plugins.default.yaml\n#    plugins: []\n#---\napiVersion:
     v1\nkind: ConfigMap\nmetadata:\n  name: default-dynamic-plugins\ndata:\n  dynamic-plugins.yaml:
     |\n    includes:\n      - dynamic-plugins.default.yaml\n    plugins:\n      -
-    disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator@1.6.0\"\n
-    \       integrity: sha512-fOSJv2PgtD2urKwBM7p9W6gV/0UIHSf4pkZ9V/wQO0eg0Zi5Mys/CL1ba3nO9x9l84MX11UBZ2r7PPVJPrmOtw==\n
+    disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator\"\n
     \       pluginConfig:\n          dynamicPlugins:\n              frontend:\n                red-hat-developer-hub.backstage-plugin-orchestrator:\n
     \                 appIcons:\n                    - importName: OrchestratorIcon\n
     \                     name: orchestratorIcon\n                  dynamicRoutes:\n
     \                   - importName: OrchestratorPage\n                      menuItem:\n
     \                       icon: orchestratorIcon\n                        text:
     Orchestrator\n                      path: /orchestrator\n      - disabled: true\n
-    \       package: \"@redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.0\"\n
-    \       integrity: sha512-Kr55YbuVwEADwGef9o9wyimcgHmiwehPeAtVHa9g2RQYoSPEa6BeOlaPzB6W5Ke3M2bN/0j0XXtpLuvrlXQogA==\n
+    \       package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend\"\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service\n        dependencies:\n
-    \         - ref: sonataflow\n      - disabled: true\n        package: \"@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.0\"\n
-    \       integrity: sha512-Bueeix4661fXEnfJ9y31Yw91LXJgw6hJUG7lPVdESCi9VwBCjDB9Rm8u2yPqP8sriwr0OMtKtqD+Odn3LOPyVw==\n
+    \         - ref: sonataflow\n      - disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator\"\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service               \n
-    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-form-widgets@1.6.0\"\n
-    \       integrity: sha512-Tqn6HO21Q1TQ7TFUoRhwBVCtSBzbQYz+OaanzzIB0R24O6YtVx3wR7Chtr5TzC05Vz5GkBO1+FZid8BKpqljgA==\n
+    \     - disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets\"\n
     \       pluginConfig:\n          dynamicPlugins:\n            frontend:\n              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets:
     { }"
   route.yaml: |-

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -357,20 +357,20 @@ data:
     \   includes:\n#      - dynamic-plugins.default.yaml\n#    plugins: []\n#---\napiVersion:
     v1\nkind: ConfigMap\nmetadata:\n  name: default-dynamic-plugins\ndata:\n  dynamic-plugins.yaml:
     |\n    includes:\n      - dynamic-plugins.default.yaml\n    plugins:\n      -
-    disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator\"\n
+    disabled: true\n        package: \"oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator\"\n
     \       pluginConfig:\n          dynamicPlugins:\n              frontend:\n                red-hat-developer-hub.backstage-plugin-orchestrator:\n
     \                 appIcons:\n                    - importName: OrchestratorIcon\n
     \                     name: orchestratorIcon\n                  dynamicRoutes:\n
     \                   - importName: OrchestratorPage\n                      menuItem:\n
     \                       icon: orchestratorIcon\n                        text:
     Orchestrator\n                      path: /orchestrator\n      - disabled: true\n
-    \       package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend\"\n
+    \       package: \"oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend\"\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service\n        dependencies:\n
-    \         - ref: sonataflow\n      - disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator\"\n
+    \         - ref: sonataflow\n      - disabled: true\n        package: \"oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator\"\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service               \n
-    \     - disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets\"\n
+    \     - disabled: true\n        package: \"oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets\"\n
     \       pluginConfig:\n          dynamicPlugins:\n            frontend:\n              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets:
     { }"
   route.yaml: |-

--- a/config/profile/rhdh/default-config/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/dynamic-plugins.yaml
@@ -30,7 +30,7 @@ data:
       - dynamic-plugins.default.yaml
     plugins:
       - disabled: true
-        package: "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator"
+        package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator"
         pluginConfig:
           dynamicPlugins:
               frontend:
@@ -45,7 +45,7 @@ data:
                         text: Orchestrator
                       path: /orchestrator
       - disabled: true
-        package: "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend"
+        package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend"
         pluginConfig:
           orchestrator:
             dataIndexService:
@@ -53,13 +53,13 @@ data:
         dependencies:
           - ref: sonataflow
       - disabled: true
-        package: "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator"
+        package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator"
         pluginConfig:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service               
       - disabled: true
-        package: "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets"
+        package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets"
         pluginConfig:
           dynamicPlugins:
             frontend:

--- a/config/profile/rhdh/default-config/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/dynamic-plugins.yaml
@@ -30,8 +30,7 @@ data:
       - dynamic-plugins.default.yaml
     plugins:
       - disabled: true
-        package: "@redhat/backstage-plugin-orchestrator@1.6.0"
-        integrity: sha512-fOSJv2PgtD2urKwBM7p9W6gV/0UIHSf4pkZ9V/wQO0eg0Zi5Mys/CL1ba3nO9x9l84MX11UBZ2r7PPVJPrmOtw==
+        package: "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator"
         pluginConfig:
           dynamicPlugins:
               frontend:
@@ -46,8 +45,7 @@ data:
                         text: Orchestrator
                       path: /orchestrator
       - disabled: true
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.0"
-        integrity: sha512-Kr55YbuVwEADwGef9o9wyimcgHmiwehPeAtVHa9g2RQYoSPEa6BeOlaPzB6W5Ke3M2bN/0j0XXtpLuvrlXQogA==
+        package: "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend"
         pluginConfig:
           orchestrator:
             dataIndexService:
@@ -55,15 +53,13 @@ data:
         dependencies:
           - ref: sonataflow
       - disabled: true
-        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.0"
-        integrity: sha512-Bueeix4661fXEnfJ9y31Yw91LXJgw6hJUG7lPVdESCi9VwBCjDB9Rm8u2yPqP8sriwr0OMtKtqD+Odn3LOPyVw==
+        package: "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator"
         pluginConfig:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service               
       - disabled: true
-        package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.6.0"
-        integrity: sha512-Tqn6HO21Q1TQ7TFUoRhwBVCtSBzbQYz+OaanzzIB0R24O6YtVx3wR7Chtr5TzC05Vz5GkBO1+FZid8BKpqljgA==
+        package: "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets"
         pluginConfig:
           dynamicPlugins:
             frontend:

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -1918,24 +1918,20 @@ data:
     \   includes:\n#      - dynamic-plugins.default.yaml\n#    plugins: []\n#---\napiVersion:
     v1\nkind: ConfigMap\nmetadata:\n  name: default-dynamic-plugins\ndata:\n  dynamic-plugins.yaml:
     |\n    includes:\n      - dynamic-plugins.default.yaml\n    plugins:\n      -
-    disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator@1.6.0\"\n
-    \       integrity: sha512-fOSJv2PgtD2urKwBM7p9W6gV/0UIHSf4pkZ9V/wQO0eg0Zi5Mys/CL1ba3nO9x9l84MX11UBZ2r7PPVJPrmOtw==\n
+    disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator\"\n
     \       pluginConfig:\n          dynamicPlugins:\n              frontend:\n                red-hat-developer-hub.backstage-plugin-orchestrator:\n
     \                 appIcons:\n                    - importName: OrchestratorIcon\n
     \                     name: orchestratorIcon\n                  dynamicRoutes:\n
     \                   - importName: OrchestratorPage\n                      menuItem:\n
     \                       icon: orchestratorIcon\n                        text:
     Orchestrator\n                      path: /orchestrator\n      - disabled: true\n
-    \       package: \"@redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.0\"\n
-    \       integrity: sha512-Kr55YbuVwEADwGef9o9wyimcgHmiwehPeAtVHa9g2RQYoSPEa6BeOlaPzB6W5Ke3M2bN/0j0XXtpLuvrlXQogA==\n
+    \       package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend\"\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service\n        dependencies:\n
-    \         - ref: sonataflow\n      - disabled: true\n        package: \"@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.0\"\n
-    \       integrity: sha512-Bueeix4661fXEnfJ9y31Yw91LXJgw6hJUG7lPVdESCi9VwBCjDB9Rm8u2yPqP8sriwr0OMtKtqD+Odn3LOPyVw==\n
+    \         - ref: sonataflow\n      - disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator\"\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service               \n
-    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-form-widgets@1.6.0\"\n
-    \       integrity: sha512-Tqn6HO21Q1TQ7TFUoRhwBVCtSBzbQYz+OaanzzIB0R24O6YtVx3wR7Chtr5TzC05Vz5GkBO1+FZid8BKpqljgA==\n
+    \     - disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets\"\n
     \       pluginConfig:\n          dynamicPlugins:\n            frontend:\n              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets:
     { }"
   route.yaml: |-

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -1918,20 +1918,20 @@ data:
     \   includes:\n#      - dynamic-plugins.default.yaml\n#    plugins: []\n#---\napiVersion:
     v1\nkind: ConfigMap\nmetadata:\n  name: default-dynamic-plugins\ndata:\n  dynamic-plugins.yaml:
     |\n    includes:\n      - dynamic-plugins.default.yaml\n    plugins:\n      -
-    disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator\"\n
+    disabled: true\n        package: \"oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator:pr_1214__3.1.3!red-hat-developer-hub-backstage-plugin-orchestrator\"\n
     \       pluginConfig:\n          dynamicPlugins:\n              frontend:\n                red-hat-developer-hub.backstage-plugin-orchestrator:\n
     \                 appIcons:\n                    - importName: OrchestratorIcon\n
     \                     name: orchestratorIcon\n                  dynamicRoutes:\n
     \                   - importName: OrchestratorPage\n                      menuItem:\n
     \                       icon: orchestratorIcon\n                        text:
     Orchestrator\n                      path: /orchestrator\n      - disabled: true\n
-    \       package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend\"\n
+    \       package: \"oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend:pr_1214__6.1.3!red-hat-developer-hub-backstage-plugin-orchestrator-backend\"\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service\n        dependencies:\n
-    \         - ref: sonataflow\n      - disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator\"\n
+    \         - ref: sonataflow\n      - disabled: true\n        package: \"oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:pr_1214__0.3.7!red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator\"\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service               \n
-    \     - disabled: true\n        package: \"ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets\"\n
+    \     - disabled: true\n        package: \"oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:pr_1214__0.2.6!red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets\"\n
     \       pluginConfig:\n          dynamicPlugins:\n            frontend:\n              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets:
     { }"
   route.yaml: |-

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -55,32 +55,35 @@ This method has similar usage and cautions as the RHDH Helper Utility.
 
 ### Installing the Orchestrator Plugin
 
-The orchestrator plugin (as of v1.5.1) consists of three dynamic plugins:
+The orchestrator plugin (as of v1.6.0) consists of four dynamic plugins:
 - orchestrator-backend
 - orchestrator-frontend
 - orchestrator-scaffolder-backend-module
+- orchestrator-form-widgets
 
-As for RHDH 1.7 all of these plugins are included in the default dynamic-plugins.yaml file of **install-dynamic-plugins** container but disabled by default.
+In RHDH 1.7, all of these plugins are included in the default dynamic-plugins.yaml file of **install-dynamic-plugins** container but disabled by default.
 To enable the orchestrator plugin, you should refer the dynamic plugins ConfigMap with following data in your Backstage Custom Resource (CR):
 ```yaml
     includes:
       - dynamic-plugins.default.yaml
     plugins:
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator@1.5.1"
+        package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator"
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1"
+        package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-backend"
         dependencies:
           - ref: sonataflow
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1"
+        package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator"
+      - disabled: false
+        package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets"
 ```
 
 See [example](/examples/orchestrator.yaml) for a complete configuration of the orchestrator plugin.
 
 #### Plugin registry
 
-As for RHDH 1.7 the orchestrator plugin packages are located in **npm.registry.redhat.com** NPM registry, which is preconfigured in rhdh default-config.
+In RHDH 1.7, the orchestrator plugin packages are as OCI images and located in **registry.redhat.io** RH registry, which is preconfigured in rhdh default-config.
 
 #### Plugin dependencies
 


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Update dynamic plugin configuration for Orchestrator to use OCI images .

## Which issue(s) does this PR fix or relate to

- Relates to Orchestrator Merge: https://issues.redhat.com/browse/FLPATH-2087

## PR acceptance criteria

- [x] Documentation

## How to test changes / Special notes to the reviewer
Please follow the[ Orchestrator Documentation](https://github.com/redhat-developer/rhdh-operator/blob/6ad0b9aedfd5b2b82fa5c0a747d24f25141a5451/docs/orchestrator.md) and let us know if any issues.

## Summary by Sourcery

Update dynamic plugin configuration to use OCI images from ghcr.io for all orchestrator-related Backstage plugins

Enhancements:
- Replace npm package references with ghcr.io OCI image URIs for orchestrator frontend plugin
- Update orchestrator backend plugin to use corresponding OCI image reference
- Switch scaffolder-backend-module-orchestrator plugin to its OCI image variant
- Point orchestrator-form-widgets plugin to its OCI image on ghcr.io