### PR TITLE
chore: tagRelease.sh: bump to 1.8.0 in main branch [skip-build]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PROFILE_SHORT := $(shell echo $(PROFILE) | cut -d. -f1)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 # Set a default VERSION if it is not defined
 ifeq ($(origin VERSION), undefined)
-VERSION ?= 0.7.0
+VERSION ?= 0.8.0
 DEFAULT_VERSION := true
 else
 DEFAULT_VERSION := false

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -327,4 +327,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
-  version: 0.7.0
+  version: 0.8.0

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,13 +35,13 @@ metadata:
           }
         }
       ]
-    createdAt: "2025-07-02T07:33:18Z"
+    createdAt: "2025-07-14T15:38:44Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   labels:
     operatorframework.io/arch.amd64: supported
-  name: backstage-operator.v0.7.0
+  name: backstage-operator.v0.8.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -214,7 +214,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/rhdh-community/operator:0.7.0
+                image: quay.io/rhdh-community/operator:0.8.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.8
-    createdAt: "2025-07-02T07:33:16Z"
+    createdAt: "2025-07-14T15:38:46Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools
     certified: "true"
-    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
+    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.8
     createdAt: "2025-07-02T07:33:16Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
@@ -59,11 +59,11 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
-    skipRange: '>=1.0.0 <1.7.0'
+    skipRange: '>=1.0.0 <1.8.0'
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
-  name: rhdh-operator.v1.7.0
+  name: rhdh-operator.v1.8.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -101,7 +101,7 @@ spec:
 
     ## Telemetry data collection
 
-    The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see [Red Hat Developer Hub documentation on telemetry data collection](https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.7/html-single/administration_guide_for_red_hat_developer_hub/index#assembly-rhdh-telemetry_admin-rhdh).
+    The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see [Red Hat Developer Hub documentation on telemetry data collection](https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.8/html-single/administration_guide_for_red_hat_developer_hub/index#assembly-rhdh-telemetry_admin-rhdh).
 
     ## More Information
 
@@ -291,7 +291,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/rhdh/rhdh-hub-rhel9:next
-                image: quay.io/rhdh/rhdh-rhel9-operator:1.7
+                image: quay.io/rhdh/rhdh-rhel9-operator:1.8
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -412,5 +412,5 @@ spec:
     name: postgresql
   - image: quay.io/rhdh/rhdh-hub-rhel9:next
     name: backstage
-  replaces: rhdh-operator.v1.6.0
-  version: 1.7.0
+  replaces: rhdh-operator.v1.7.0
+  version: 1.8.0

--- a/config/manifests/rhdh/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/rhdh/bases/backstage-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools
     certified: "true"
-    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.7
+    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.8
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed
@@ -23,7 +23,7 @@ metadata:
     operatorframework.io/suggested-namespace: rhdh-operator
     operators.openshift.io/valid-subscription: '["Red Hat Developer Hub"]'
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
-    skipRange: '>=1.0.0 <1.7.0'
+    skipRange: '>=1.0.0 <1.8.0'
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
@@ -65,7 +65,7 @@ spec:
 
     ## Telemetry data collection
 
-    The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see [Red Hat Developer Hub documentation on telemetry data collection](https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.7/html-single/administration_guide_for_red_hat_developer_hub/index#assembly-rhdh-telemetry_admin-rhdh).
+    The telemetry data collection feature is enabled by default. Red Hat Developer Hub sends telemetry data to Red Hat by using the `backstage-plugin-analytics-provider-segment` plugin. To disable this and to learn what data is being collected, see [Red Hat Developer Hub documentation on telemetry data collection](https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.8/html-single/administration_guide_for_red_hat_developer_hub/index#assembly-rhdh-telemetry_admin-rhdh).
 
     ## More Information
 
@@ -113,5 +113,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
-  replaces: rhdh-operator.v1.6.0
-  version: 1.7.0
+  replaces: rhdh-operator.v1.7.0
+  version: 1.8.0

--- a/config/profile/backstage.io/kustomization.yaml
+++ b/config/profile/backstage.io/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.7.0
+  newTag: 0.8.0
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/profile/rhdh/kustomization.yaml
+++ b/config/profile/rhdh/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 images:
 - name: controller
   newName: quay.io/rhdh/rhdh-rhel9-operator
-  newTag: "1.7"
+  newTag: "1.8"
 
 patches:
 - path: patches/deployment-patch.yaml

--- a/dist/backstage.io/install.yaml
+++ b/dist/backstage.io/install.yaml
@@ -1796,7 +1796,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: quay.io/rhdh-community/operator:0.7.0
+        image: quay.io/rhdh-community/operator:0.8.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -2185,7 +2185,7 @@ spec:
           value: quay.io/fedora/postgresql-15:latest
         - name: RELATED_IMAGE_backstage
           value: quay.io/rhdh/rhdh-hub-rhel9:next
-        image: quay.io/rhdh/rhdh-rhel9-operator:1.7
+        image: quay.io/rhdh/rhdh-rhel9-operator:1.8
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>

## Summary by Sourcery

Bump release version to 1.8.0 across manifests and scripts

Chores:
- Update operator containerImage references from 1.7 to 1.8
- Adjust skipRange, replaces, and version fields to 1.8.0 in CSV manifests
- Update telemetry documentation links to reference version 1.8
- Bump default Makefile VERSION from 0.7.0 to 0.8.0
- Update backstage bundle manifest version to 0.8.0