### PR TITLE
fix: nightly workflow checkout to use correct branch for each matrix job

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,8 +24,9 @@ jobs:
     env:
       CONTAINER_TOOL: podman
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 # default branch will be checked out by default on scheduled workflows
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          ref: ${{ matrix.branch }}
           fetch-depth: 0
 
       - name: Setup Go


### PR DESCRIPTION
Currently all matrix jobs checkout main branch code but use different operator images, causing version mismatches where newer tests run against older operators.

This adds explicit branch checkout so each matrix job gets:
- main: main code + main operator
- release-1.7: release-1.7 code + release-1.7 operator
- release-1.6: release-1.6 code + release-1.6 operator

Fixes nightly test failures where v1alpha4 API tests were running against operators that don't support v1alpha4.

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Use the matrix-defined branch when checking out code in the nightly GitHub Actions workflow to align tests with the correct operator version

Bug Fixes:
- Prevent version mismatches by ensuring each matrix job runs code and operator from the same branch, fixing v1alpha4 compatibility failures

CI:
- Add ‘ref: ${{ matrix.branch }}’ to the actions/checkout step in nightly.yaml