### PR TITLE
chore: change behavior of filtered versions for restricted env.

### DIFF
--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -79,7 +79,7 @@ Options:
                                             Setting this to 'true' causes the script to replace all references to the internal RH registries
                                             with quay.io when mirroring images. Relevant only if '--use-oc-mirror' is 'false'. 
                                             When set to 'true', --filter-versions must be explicitly specified. Default: false
-  --filter-versions <list>               : Comma-separated list of operator minor versions to keep in the catalog (default: $FILTERED_VERSIONS_CSV).
+  --filter-versions <list>               : Comma-separated list of operator minor versions to keep in the catalog (default: * (all versions)).
                                             Specify '*' to disable version filtering and include all channels and all versions.
                                             Useful for CI index images for example.
   --to-registry <registry_url>           : Mirror the images into the specified registry, assuming you are already logged into it.
@@ -184,6 +184,7 @@ while [[ "$#" -gt 0 ]]; do
     shift 1
     ;;
   '--prod_operator_version')
+    FILTER_VERSIONS_PROVIDED="true"
     input="${2#v}"
     IFS='.' read -ra parts <<<"$input"
     length=${#parts[@]}

--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -133,7 +133,7 @@ Examples:
   # It will automatically replace all references to the internal RH registries with quay.io
   $0 \\
     --ci-index true \\
-    --filter-versions "1.4,1.5"
+    --filter-versions '1.4,1.5'
 "
 }
 

--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -15,7 +15,7 @@ IS_HOSTED_CONTROL_PLANE=""
 
 NAMESPACE_OPERATOR="rhdh-operator"
 INDEX_IMAGE="registry.redhat.io/redhat/redhat-operator-index:v4.18"
-FILTERED_VERSIONS=(1.4 1.5)
+FILTERED_VERSIONS=(*)
 
 # assume mikefarah version of yq is already available on the path; if 1, then install the version shown
 INSTALL_YQ=0
@@ -77,7 +77,8 @@ Options:
   --index-image <operator-index-image>   : Operator index image (default: $INDEX_IMAGE)
   --ci-index <true|false>                : Indicates that the index image is a CI build. Unsupported.
                                             Setting this to 'true' causes the script to replace all references to the internal RH registries
-                                            with quay.io when mirroring images. Relevant only if '--use-oc-mirror' is 'false'. Default: false
+                                            with quay.io when mirroring images. Relevant only if '--use-oc-mirror' is 'false'. 
+                                            When set to 'true', --filter-versions must be explicitly specified. Default: false
   --filter-versions <list>               : Comma-separated list of operator minor versions to keep in the catalog (default: $FILTERED_VERSIONS_CSV).
                                             Specify '*' to disable version filtering and include all channels and all versions.
                                             Useful for CI index images for example.
@@ -131,7 +132,8 @@ Examples:
   #   because it detected that it is connected to an OCP cluster.
   # It will automatically replace all references to the internal RH registries with quay.io
   $0 \\
-    --ci-index true
+    --ci-index true \\
+    --filter-versions "1.4,1.5"
 "
 }
 
@@ -147,6 +149,7 @@ OC_MIRROR_PATH="oc-mirror"
 OC_MIRROR_FLAGS=""
 
 NO_VERSION_FILTER="false"
+FILTER_VERSIONS_PROVIDED="false"
 
 # example usage:
 # ./prepare-restricted-environment.sh \
@@ -203,6 +206,7 @@ while [[ "$#" -gt 0 ]]; do
     shift 1
     ;;
   '--filter-versions')
+    FILTER_VERSIONS_PROVIDED="true"
     if [[ "$2" == "*" ]]; then
       NO_VERSION_FILTER="true"
     else
@@ -348,6 +352,12 @@ fi
 if [[ -n "${FROM_DIR}" && -z "${TO_REGISTRY}" ]]; then
   errorf "--to-registry is needed when --from-dir is specified."
   exit 1
+fi
+if [[ "${IS_CI_INDEX_IMAGE}" == "true" ]]; then
+  if [[ "${FILTER_VERSIONS_PROVIDED}" == "false" ]]; then
+    errorf "When --ci-index is true, --filter-versions must be specified."
+    exit 1
+  fi
 fi
 
 if [[ -n "${TO_DIR}" ]]; then


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
Change the behavior of `prepare-restricted-environment.sh` script so that by default, no versions are filtered.

Also, for CI images (when using `--ci-index`), require to specify the version filter by `--filter-versions` flag. This option is used only for testing purposes, where you want to test one specific image.

## Which issue(s) does this PR fix or relate to

- Fixes [RHIDP-8502](https://issues.redhat.com/browse/RHIDP-8502)

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Update prepare-restricted-environment.sh to disable default version filtering and enforce explicit version filter for CI index images

Enhancements:
- Change default FILTERED_VERSIONS to '*' to include all operator versions by default
- Require --filter-versions flag when --ci-index is true and exit with error if missing
- Update script usage instructions to reflect new default behavior and CI requirement