### PR TITLE
Add Network Policy for Orchestrator (#1481)

### DIFF
--- a/bundle/rhdh/manifests/rhdh-plugin-deps_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-plugin-deps_v1_configmap.yaml
@@ -4,7 +4,7 @@ data:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      name: allow-knative-to-sonataflow-and-workflows # hardcoded
+      name: allow-infra-ns-to-workflow-ns # hardcoded
     spec:
       podSelector: {}
       ingress:
@@ -17,6 +17,10 @@ data:
                 matchLabels:
                   # Allow auxiliary knative function for workflow (such as m2k-save-transformation)
                   kubernetes.io/metadata.name: knative-serving
+            - namespaceSelector:
+                matchLabels:
+                  # Allow openshift serverless logic operator controller pod to access all pods in sonataflow
+                  kubernetes.io/metadata.name: openshift-serverless-logic
     ---
     # NetworkPolicy to unblock incoming traffic to the namespace
     apiVersion: networking.k8s.io/v1

--- a/config/profile/rhdh/plugin-deps/sonataflow.yaml
+++ b/config/profile/rhdh/plugin-deps/sonataflow.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-knative-to-sonataflow-and-workflows # hardcoded
+  name: allow-infra-ns-to-workflow-ns # hardcoded
 spec:
   podSelector: {}
   ingress:
@@ -14,6 +14,10 @@ spec:
             matchLabels:
               # Allow auxiliary knative function for workflow (such as m2k-save-transformation)
               kubernetes.io/metadata.name: knative-serving
+        - namespaceSelector:
+            matchLabels:
+              # Allow openshift serverless logic operator controller pod to access all pods in sonataflow
+              kubernetes.io/metadata.name: openshift-serverless-logic
 ---
 # NetworkPolicy to unblock incoming traffic to the namespace
 apiVersion: networking.k8s.io/v1

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -2008,7 +2008,7 @@ data:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      name: allow-knative-to-sonataflow-and-workflows # hardcoded
+      name: allow-infra-ns-to-workflow-ns # hardcoded
     spec:
       podSelector: {}
       ingress:
@@ -2021,6 +2021,10 @@ data:
                 matchLabels:
                   # Allow auxiliary knative function for workflow (such as m2k-save-transformation)
                   kubernetes.io/metadata.name: knative-serving
+            - namespaceSelector:
+                matchLabels:
+                  # Allow openshift serverless logic operator controller pod to access all pods in sonataflow
+                  kubernetes.io/metadata.name: openshift-serverless-logic
     ---
     # NetworkPolicy to unblock incoming traffic to the namespace
     apiVersion: networking.k8s.io/v1

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -89,7 +89,7 @@ As for RHDH 1.7 the orchestrator plugin packages are located in **npm.registry.r
 
 The orchestrator plugin instance requires the following dependencies to be installed:
 - A SonataflowPlatform custom resource - created in the namespace of the Backstage CR.
-- A set of NetworkPolicies to allow traffic between Knative resources created in the namespace of Backstage CR, traffic for monitoring, and intra-namespace traffic.
+- A set of NetworkPolicies to allow traffic between infra resources (knative and serverless logic operator) created in the namespace of Backstage CR, traffic for monitoring, and intra-namespace traffic.
 
 The orchestrator-backend plugin uses the service **sonataflow-platform-data-index-service**, which is created by the SonataFlowPlatform CR. This service is used to communicate with the SonataFlow platform.
 


### PR DESCRIPTION
* Add network policy to allow ingress traffic from osl operator to sonataflow.
---------


(cherry picked from commit caff666aef1509ba673564d8d9009354764c88cb)

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Related to https://github.com/redhat-developer/rhdh-operator/pull/1481
-->

## Which issue(s) does this PR fix or relate to

- Relates to PR: https://github.com/redhat-developer/rhdh-operator/pull/1481

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## Summary by Sourcery

Include the openshift-serverless-logic operator in orchestrator network policies and rename policies for broader infra traffic support

New Features:
- Add ingress rule to network policies to allow traffic from the openshift-serverless-logic operator namespace

Enhancements:
- Rename network policy resources from allow-knative-to-sonataflow-and-workflows to allow-infra-ns-to-workflow-ns across manifests

Documentation:
- Update orchestrator documentation to describe network policies for infra resources (knative and serverless logic operator)