### PR TITLE
Update renovate-checks.yaml

### DIFF
--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Validate config
         # See https://docs.renovatebot.com/config-validation/
         run: |
-          npx --yes --package renovate -- renovate-config-validator --strict .github/renovate.json
+          npx --yes --package renovate@36.0.0 -- renovate-config-validator --strict .github/renovate.json


### PR DESCRIPTION
## Description

Use explicit version of renovate to avoid caching issue

## Summary by Sourcery

CI:
- Pin renovate to version 36.0.0 in the renovate-checks workflow validation step