### PR TITLE
Update renovate-checks.yaml

### DIFF
--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -17,4 +17,4 @@ jobs:
       - name: Validate config
         # See https://docs.renovatebot.com/config-validation/
         run: |
-          npx --yes --package renovate@36.0.0 -- renovate-config-validator --strict .github/renovate.json
+          npx --yes --package renovate@latest -- renovate-config-validator --strict .github/renovate.json


### PR DESCRIPTION
latest renovate

## Summary by Sourcery

CI:
- Use renovate@latest instead of renovate@36.0.0 in the config validation step