### PR TITLE
Update renovate-checks.yaml

### DIFF
--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -14,6 +14,9 @@ jobs:
     name: Renovate Config Validator
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - name: Print Renovate version
+        run: |
+          npx --yes --package renovate@37.0.0 -- renovate --version
       - name: Validate config
         # See https://docs.renovatebot.com/config-validation/
         run: |


### PR DESCRIPTION
print renovate version

## Summary by Sourcery

CI:
- Add a step in renovate-checks.yaml to run 'npx renovate --version' before validating the config