### PR TITLE
Remove forcibly deleting resources that cannot be patched

### DIFF
--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -14,7 +14,8 @@ jobs:
     name: Renovate Config Validator
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Print Renovate version
+      - name: Print actual renovate version
+        # To make sure we are using the latest (not cached) renovate version
         run: |
           npx --yes --package renovate@latest -- renovate --version
       - name: Validate config

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha2
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha3
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/api/v1alpha4/zz_generated.deepcopy.go
+++ b/api/v1alpha4/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha4
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/integration_tests/cr-compatibility_test.go
+++ b/integration_tests/cr-compatibility_test.go
@@ -175,4 +175,5 @@ var _ = When("testing API version compatibility", func() {
 		err = k8sClient.Delete(ctx, bsV1Alpha4)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
+
 })

--- a/internal/controller/monitor.go
+++ b/internal/controller/monitor.go
@@ -17,10 +17,8 @@ import (
 func (r *BackstageReconciler) applyServiceMonitor(ctx context.Context, backstage *bs.Backstage) error {
 	lg := log.FromContext(ctx).WithValues("Backstage", backstage.Name)
 
-	lg.Info("Checking monitoring status", "enabled", backstage.Spec.IsMonitoringEnabled())
-
 	if !backstage.Spec.IsMonitoringEnabled() {
-		lg.Info("Monitoring disabled, deleting any existing ServiceMonitor")
+		lg.Info("monitoring disabled, deleting any existing ServiceMonitor")
 		return r.tryToDelete(ctx,
 			&monitoringv1.ServiceMonitor{},
 			utils.GenerateRuntimeObjectName(backstage.Name, "metrics"),


### PR DESCRIPTION
## Description

Remove forcibly deleting resources that cannot be patched

## Which issue(s) does this PR fix or relate to

https://issues.redhat.com/browse/RHDHBUGS-1898

## PR acceptance criteria

- [x] Tests

## Summary by Sourcery

Remove force-deletion fallback for unpatchable resources and clean up related logic

Bug Fixes:
- Prevent forcible deletion of resources on patch failures by removing the upgrade glitch workaround

Enhancements:
- Simplify applyPayload to directly return patch errors instead of deleting resources
- Streamline monitoring log output when ServiceMonitor is disabled

CI:
- Update Renovate workflow to always use the latest version and clarify the step name

Tests:
- Add missing newline at end of the cr-compatibility integration test

Chores:
- Regenerate deepcopy functions across all API versions