### PR TITLE
chore: Bump the Go version to 1.24 [RHIDP-8052]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
     "/^release-1\\..*/"
   ],
   "constraints": {
-    "go": "1.23"
+    "go": "1.24"
   },
   "kustomize": {
     "enabled": false

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -77,7 +77,7 @@ jobs:
             echo "[SeaLights] Downloading SeaLights Golang & CLI Agents..."
             # Architectures available: darwin-amd64, darwin-arm64, linux-amd64, linux-arm64
             SL_OS_ARCH=linux-amd64
-            SL_GO_AGENT_VERSION=v1.1.193
+            SL_GO_AGENT_VERSION=v1.1.196
             SL_CLI_AGENT_VERSION=v1.0.49
 
             wget -nv -O sealights-go-agent.tar.gz https://agents.sealights.co/slgoagent/${SL_GO_AGENT_VERSION}/slgoagent-${SL_OS_ARCH}.tar.gz

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -82,7 +82,7 @@ jobs:
             echo "[SeaLights] Downloading SeaLights Golang & CLI Agents..."
             # Architectures available: darwin-amd64, darwin-arm64, linux-amd64, linux-arm64
             SL_OS_ARCH=linux-amd64
-            SL_GO_AGENT_VERSION=v1.1.195
+            SL_GO_AGENT_VERSION=v1.1.196
             SL_CLI_AGENT_VERSION=v1.0.49
 
             wget -nv -O sealights-go-agent.tar.gz https://agents.sealights.co/slgoagent/${SL_GO_AGENT_VERSION}/slgoagent-${SL_OS_ARCH}.tar.gz

--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 #@follow_tag(registry.redhat.io/rhel9/go-toolset:latest)
 # https://registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1755755147@sha256:d1c1f2af6122b0ea3456844210d6d9c4d96e78c128bc02fabeadf51239202221 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1755755147@sha256:bf383be26fef83d546ade1615ae3e80cc733cab62b9a04682c088ec808e0106f AS builder
 ARG TARGETOS
 ARG TARGETARCH
 # hadolint ignore=DL3002
@@ -38,8 +38,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Install openssl for FIPS support
 #@follow_tag(registry.redhat.io/ubi9/ubi-minimal:latest)
 # https://registry.access.redhat.com/ubi9/ubi-minimal
-FROM registry.access.redhat.com/ubi9-minimal:9.6-1755695350@sha256:2f06ae0e6d3d9c4f610d32c480338eef474867f435d8d28625f2985e8acde6e8 AS runtime
-
+FROM registry.access.redhat.com/ubi9-minimal:9.6-1755695350@sha256:3660caede14750ab8df58f780016be487e490055acf07f67333c0001c661c913 AS runtime
 # Downstream uncomment
 RUN cat /cachi2/cachi2.env
 #/ Downstream uncomment

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 #@follow_tag(registry.redhat.io/rhel9/go-toolset:latest)
 # https://registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1755755147@sha256:d1c1f2af6122b0ea3456844210d6d9c4d96e78c128bc02fabeadf51239202221 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.6-1755755147@sha256:bf383be26fef83d546ade1615ae3e80cc733cab62b9a04682c088ec808e0106f AS builder
 ARG TARGETOS
 ARG TARGETARCH
 # hadolint ignore=DL3002
@@ -38,8 +38,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Install openssl for FIPS support
 #@follow_tag(registry.redhat.io/ubi9/ubi-minimal:latest)
 # https://registry.access.redhat.com/ubi9/ubi-minimal
-FROM registry.access.redhat.com/ubi9-minimal:9.6-1755695350@sha256:2f06ae0e6d3d9c4f610d32c480338eef474867f435d8d28625f2985e8acde6e8 AS runtime
-
+FROM registry.access.redhat.com/ubi9-minimal:9.6-1755695350@sha256:3660caede14750ab8df58f780016be487e490055acf07f67333c0001c661c913 AS runtime
 # Downstream uncomment
 # RUN cat /cachi2/cachi2.env
 #/ Downstream uncomment

--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
 GOLANGCI_LINT_VERSION ?= v1.64.8
 GOIMPORTS_VERSION ?= v0.16.1
-GOSEC_VERSION ?= v2.20.0
+GOSEC_VERSION ?= v2.22.8
 GINKGO_VERSION ?= v2.22.2
 
 ## Gosec options - default format is sarif so we can integrate with Github code scanning

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Operator provides clear and flexible configuration options to satisfy a wide
 ## Getting Started
 
 ### Prerequisites
-- go version v1.23.0+
+- go version v1.24.0+
 
 ### To Deploy on the cluster
 You’ll need a Kubernetes or OpenShift cluster. You can use [Minikube](https://minikube.sigs.k8s.io/docs/) or [KIND](https://sigs.k8s.io/kind) for local testing, or deploy to a remote cluster.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/redhat-developer/rhdh-operator
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.9
+toolchain go1.24.6
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.2


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Bumps Go to 1.24, now that registry.redhat.io/ubi9/go-toolset:1.24 is available. It also bumps the base ubi-minimal image to 9.6 (latest available at this time).

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-8052

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Bump Go version to 1.24 and update related base images and documentation

Chores:
- Update go.mod and toolchain to Go 1.24
- Update Dockerfiles to use Go 1.24 go-toolset and UBI 9.6 base images
- Update README to require Go version 1.24.0+