### PR TITLE
ci(nightly): Fix the nightly tests [RHDHBUGS-1985]

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -116,6 +116,14 @@ jobs:
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         run: ./slcli test start-stage --bsid=buildSessionId.txt --testStage "Unit Tests"
 
+      - name: Create Kind cluster
+        # TODO(asoro): a cluster is needed on release-1.6 (and before) branches due to RHDHBUGS-461. Remove this step when 1.6 is EOL.
+        if: ${{ matrix.branch == 'release-1.6' && steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: integration-test-cluster
+          ignore_failed_clean: true
+
       - name: Test
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         # run this stage only if there are changes that match the includes and not the excludes
@@ -128,7 +136,7 @@ jobs:
           ./slcli test start-stage --bsid=buildSessionId.txt --testStage "Integration Tests"
 
       - name: Create Kind cluster (integration tests)
-        if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
+        if: ${{ matrix.branch != 'release-1.6' && steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           cluster_name: integration-test-cluster

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 # Source packages outside of tests
-PKGS := $(shell go list ./... | grep -v /e2e | grep -v /v1alpha1 | grep -v /v1alpha2)
+PKGS := $(shell go list ./... | grep -vE 'github.com/redhat-developer/rhdh-operator/(tests/|integration_tests|api/v1alpha([1-2]))')
 
 .PHONY: all
 all: build


### PR DESCRIPTION
## Description
Fixes the nightly checks reported in https://github.com/redhat-developer/rhdh-operator/actions/runs/17253109898/job/48959475404

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHDHBUGS-1985

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Fix nightly CI workflow failures by adjusting Kind cluster creation conditions for different branches and refining package filtering in the build process

Build:
- Update Makefile PKGS variable to exclude tests, integration_tests, and API v1alpha1/v1alpha2 packages

CI:
- Refine Kind cluster creation steps in nightly workflow to run only on release-1.6 for pre-1.6 branches and on other branches for integration tests