### PR TITLE
[release-1.6] ci: Fix authorization logic in pull_request_target workflows (#1563)

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -21,7 +21,7 @@ jobs:
     # see list of approvers in OWNERS file
     environment:
       ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(fromJSON('["coreydaley","gazarenkov","kadel","nickboldt","rm3l","kim-tsao","openshift-cherrypick-robot"]'), github.actor)) && 'internal' || 'external' }}
+      contains(fromJSON('["gazarenkov","kadel","nickboldt","rm3l","kim-tsao","openshift-cherrypick-robot"]'), github.event.pull_request.user.login)) && 'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
       - name: approved
@@ -40,7 +40,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: ${{github.event.pull_request.head.repo.full_name}}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -28,7 +28,7 @@ jobs:
     # see list of approvers in OWNERS file
     environment:
       ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
-        contains(fromJSON('["coreydaley","gazarenkov","kadel","nickboldt","rm3l","kim-tsao","openshift-cherrypick-robot"]'), github.actor)) && 'internal' || 'external' }}
+        contains(fromJSON('["gazarenkov","kadel","nickboldt","rm3l","kim-tsao","openshift-cherrypick-robot"]'), github.event.pull_request.user.login)) && 'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
       - name: approved
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: ${{github.event.pull_request.head.repo.full_name}}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # check changes in this commit for regex include and exclude matches
       - name: Get changed files


### PR DESCRIPTION
## Description

Manual cherry-pick of https://github.com/redhat-developer/rhdh-operator/pull/1563

## Summary by Sourcery

Fix the pull_request_target CI workflows by updating the authorization logic to use the PR author’s login against an updated approvers list and by checking out the exact commit SHA rather than the branch ref.

CI:
- Determine internal/external environment using github.event.pull_request.user.login with a revised approvers list
- Use github.event.pull_request.head.sha for the checkout ref instead of head.ref in PR workflows