### PR TITLE
doc: add backend_secret config to orchestrator

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -91,7 +91,9 @@ To enable the orchestrator plugin, you should refer the dynamic plugins ConfigMa
          disabled: false  
 ```
 
-See [example](/examples/orchestrator.yaml) for a complete configuration of the orchestrator plugin.
+See [example](/examples/orchestrator.yaml) for a complete configuration of the orchestrator plugin. 
+Ensure to add a secret with the BACKEND_SECRET key/value and update
+the secret name in the `Backstage` CR under the `extraEnvs` field.
 
 #### Plugin registry
 

--- a/examples/orchestrator.yaml
+++ b/examples/orchestrator.yaml
@@ -53,4 +53,4 @@ spec:
     dynamicPluginsConfigMapName: orchestrator-plugin
     extraEnvs:
       secrets:
-        - name: backstage-backend-auth-secret
+        - name: backstage-backend-auth-secret # secret that contains the BACKEND_SECRET key

--- a/examples/orchestrator.yaml
+++ b/examples/orchestrator.yaml
@@ -33,6 +33,13 @@ data:
         guest:
           # using the guest user to query the '/api/dynamic-plugins-info/loaded-plugins' endpoint.
           dangerouslyAllowOutsideDevelopment: true
+    backend:
+      auth:
+        externalAccess:
+          - type: static
+            options:
+              token: ${BACKEND_SECRET}
+              subject: orchestrator
 ---
 apiVersion: rhdh.redhat.com/v1alpha4
 kind: Backstage
@@ -44,3 +51,6 @@ spec:
       configMaps:
         - name: app-config-rhdh
     dynamicPluginsConfigMapName: orchestrator-plugin
+    extraEnvs:
+      secrets:
+        - name: backstage-backend-auth-secret


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
To enable notification for Orchestrator, this PR adds the backend secret token under the auth config in the orchestrator example. So the user is aware that the secret needs to be configured for Orchestrator.

## Which issue(s) does this PR fix or relate to

- Relates to bug ticket: https://issues.redhat.com/browse/FLPATH-2627

## PR acceptance criteria

- [x] Documentation
