### PR TITLE
[release-1.7] doc: add backend_secret config to orchestrator (#1567)

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -79,7 +79,9 @@ To enable the orchestrator plugin, you should refer the dynamic plugins ConfigMa
          disabled: false  
 ```
 
-See [example](/examples/orchestrator.yaml) for a complete configuration of the orchestrator plugin.
+See [example](/examples/orchestrator.yaml) for a complete configuration of the orchestrator plugin. 
+Ensure to add a secret with the BACKEND_SECRET key/value and update
+the secret name in the `Backstage` CR under the `extraEnvs` field.
 
 #### Plugin registry
 

--- a/examples/orchestrator.yaml
+++ b/examples/orchestrator.yaml
@@ -30,6 +30,22 @@ data:
         guest:
           # using the guest user to query the '/api/dynamic-plugins-info/loaded-plugins' endpoint.
           dangerouslyAllowOutsideDevelopment: true
+    backend:
+      auth:
+        externalAccess:
+          - type: static
+            options:
+              token: ${BACKEND_SECRET}
+              subject: orchestrator
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-auth-secret
+stringData:
+  # generated with the command below (from https://backstage.io/docs/auth/service-to-service-auth/#setup):
+  # node -p 'require("crypto").randomBytes(24).toString("base64")'
+  BACKEND_SECRET: "R2FxRVNrcmwzYzhhN3l0V1VRcnQ3L1pLT09WaVhDNUEK" # notsecret
 ---
 apiVersion: rhdh.redhat.com/v1alpha3
 kind: Backstage
@@ -41,3 +57,6 @@ spec:
       configMaps:
         - name: app-config-rhdh
     dynamicPluginsConfigMapName: orchestrator-plugin
+    extraEnvs:
+      secrets:
+        - name: backend-auth-secret # secret that contains the BACKEND_SECRET key


### PR DESCRIPTION
## Description
Manual cherry-pick of https://github.com/redhat-developer/rhdh-operator/pull/1567, because of a conflict error: https://github.com/redhat-developer/rhdh-operator/pull/1567#issuecomment-3245940957

## Which issue(s) does this PR fix or relate to

- Relates to https://issues.redhat.com/browse/FLPATH-2627

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Add backend_secret configuration support to the orchestrator plugin by providing a sample Secret, updating the example manifest, and adjusting documentation to guide users through secret setup and referencing in the Backstage CR.

New Features:
- Add static backend auth token configuration to the orchestrator example
- Include a sample Kubernetes Secret resource to hold the BACKEND_SECRET
- Expose the BACKEND_SECRET via extraEnvs in the Backstage custom resource

Documentation:
- Update orchestrator documentation to instruct adding the BACKEND_SECRET secret and configuring extraEnvs