### PR TITLE
Test qodo- remove legacy

### DIFF
--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -162,41 +162,6 @@ FILTER_VERSIONS_PROVIDED="false"
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-  # Legacy options. Deprecated but kept for backward compatibility
-  '--prod_operator_index')
-    INDEX_IMAGE="$2"
-    shift 1
-    ;;
-  '--prod_operator_package_name')
-    debugf "--prod_operator_package_name ($2) is no longer used"
-    shift 1
-    ;;
-  '--prod_operator_bundle_name')
-    debugf "--prod_operator_bundle_name ($2) is no longer used"
-    shift 1
-    ;;
-  '--helper_mirror_registry_storage')
-    debugf "--helper_mirror_registry_storage is no longer used. This script assumes you already have a mirror registry in your disconnected environment"
-    shift 1
-    ;;
-  '--use_existing_mirror_registry')
-    debugf "--use_existing_mirror_registry is no longer used. This script assumes you already have a mirror registry in your disconnected environment"
-    shift 1
-    ;;
-  '--prod_operator_version')
-    FILTER_VERSIONS_PROVIDED="true"
-    input="${2#v}"
-    IFS='.' read -ra parts <<<"$input"
-    length=${#parts[@]}
-    if [ "$length" -ge 2 ]; then
-      FILTERED_VERSIONS=("${parts[0]}"."${parts[1]}")
-    else
-      FILTERED_VERSIONS=("${parts[*]}")
-    fi
-    debugf "${FILTERED_VERSIONS[@]}"
-    shift 1
-    ;;
-
   # New options
   '--index-image')
     INDEX_IMAGE="$2"


### PR DESCRIPTION
### **User description**
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-433

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Remove legacy command-line options and their handling from prepare-restricted-environment.sh script

Enhancements:
- Remove deprecated production operator and mirror registry CLI flags (--prod_operator_* and related)
- Remove version filtering logic for the --prod_operator_version flag


___

### **PR Type**
Enhancement


___

### **Description**
- Remove deprecated command-line options from script

- Clean up legacy production operator flags

- Eliminate version filtering logic for old parameters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Legacy CLI Options"] -- "Remove" --> B["Cleaned Script"]
  C["--prod_operator_*"] -- "Delete" --> B
  D["Version Filtering Logic"] -- "Remove" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prepare-restricted-environment.sh</strong><dd><code>Remove legacy command-line options and handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.rhdh/scripts/prepare-restricted-environment.sh

<ul><li>Remove deprecated <code>--prod_operator_*</code> command-line flags<br> <li> Delete legacy mirror registry storage options<br> <li> Remove version filtering logic for <code>--prod_operator_version</code><br> <li> Clean up backward compatibility code</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-operator/pull/1577/files#diff-50e0081f1ed7aba1428b1ce13b3d65b911feb1fe5ed2eb12cd384830dde90497">+0/-35</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

