### PR TITLE
Change checkout ref to use head.ref instead of sha

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: ${{github.event.pull_request.head.repo.full_name}}
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5


### PR DESCRIPTION
### **User description**
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->


___

### **PR Type**
Other


___

### **Description**
- Change GitHub Actions checkout reference from SHA to branch name


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub PR Event"] --> B["Checkout Action"]
  B --> C["head.sha (old)"]
  B --> D["head.ref (new)"]
  C -.-> E["Specific commit"]
  D --> F["Branch reference"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-bundle-diff-checks.yaml</strong><dd><code>Update checkout reference parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-bundle-diff-checks.yaml

<ul><li>Modified checkout action to use <code>head.ref</code> instead of <code>head.sha</code><br> <li> Changed from specific commit SHA to branch reference</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-developer/rhdh-operator/pull/1590/files#diff-905e72c3b810c34ac0c8ae2004188e7f2826c2c5714924a2707e40eaa3862de5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## Summary by Sourcery

CI:
- Use github.event.pull_request.head.ref for the checkout action instead of head.sha