### PR TITLE
Update checkout action to use SHA instead of ref

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
           repository: ${{github.event.pull_request.head.repo.full_name}}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

CI:
- Switch checkout action to use github.event.pull_request.head.sha rather than head.ref in pr-bundle-diff-checks.yaml