### PR TITLE
fix(ci): Make sure to checkout the PR branch before pushing the bundle diff generated

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -60,18 +60,22 @@ jobs:
           # Inspired from https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
           echo "MANIFESTS_CHANGED=$(if git diff --quiet -I'^    createdAt: ' bundle config dist; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
 
-      - name: Commit any manifest changes
+      - name: Commit and push any manifest changes
         if: ${{ steps.manifests-diff-checker.outputs.MANIFESTS_CHANGED == 'true' }}
         run: |
+          git remote add fork "https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git"
+          git fetch fork ${{ github.event.pull_request.head.ref }}
+          git checkout -B pr-branch fork/${{ github.event.pull_request.head.ref }}
+
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git fetch --prune
-          git pull --rebase --autostash
+
           git add -A .
           git commit \
             -m "Regenerate bundle/installer manifests" \
             -m "Co-authored-by: $GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
-          git push
+
+          git push fork pr-branch:${{ github.event.pull_request.head.ref }}
 
       - name: Comment on PR if manifests were updated
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
## Description

Should hopefully fix https://github.com/redhat-developer/rhdh-operator/actions/runs/17475391158/job/49670949036?pr=1584

This only affects workflows that have steps that auto-commit/push certain changes to the PR branch.

## Which issue(s) does this PR fix or relate to

Some failures on PR checks: https://github.com/redhat-developer/rhdh-operator/actions/runs/17475391158/job/49670949036?pr=1584

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

CI:
- Configure and fetch the PR fork, checkout its head branch, and push bundle/installer manifest updates back to the PR