### PR TITLE
ci(nightly): Always display Operator logs at the end of the E2E tests

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -24,6 +24,7 @@ const (
 	defaultDeployTestMode = ""
 )
 
+var _start time.Time
 var _namespace = "rhdh-operator"
 var testMode = os.Getenv("BACKSTAGE_OPERATOR_TEST_MODE")
 var managerPodLabel = "app=rhdh-operator"
@@ -183,6 +184,7 @@ func installOperatorWithMakeDeploy(withOlm bool) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
+	_start = time.Now()
 	//runs *only* on process #1
 	fmt.Fprintln(GinkgoWriter, "isOpenshift:", helper.IsOpenShift())
 
@@ -215,11 +217,13 @@ var _ = SynchronizedAfterSuite(func() {
 	//runs on *all* processes
 },
 	// the function below *only* on process #1
-	uninstallOperator,
+	func() {
+		defer uninstallOperator()
+		fmt.Println(fetchOperatorLogs(managerPodLabel, false)())
+	},
 )
 
-func verifyControllerUp(g Gomega, managerPodLabel string) {
-	// Get pod name
+func getControllerPodName() (string, error) {
 	cmd := exec.Command(helper.GetPlatformTool(), "get",
 		"pods", "-l", managerPodLabel,
 		"-o", "go-template={{ range .items }}{{ if not .metadata.deletionTimestamp }}{{ .metadata.name }}"+
@@ -227,14 +231,22 @@ func verifyControllerUp(g Gomega, managerPodLabel string) {
 		"-n", _namespace,
 	)
 	podOutput, err := helper.Run(cmd)
-	g.Expect(err).ShouldNot(HaveOccurred())
+	if err != nil {
+		return "", err
+	}
 	podNames := helper.GetNonEmptyLines(string(podOutput))
-	g.Expect(podNames).Should(HaveLen(1), fmt.Sprintf("expected 1 controller pods running, but got %d", len(podNames)))
-	controllerPodName := podNames[0]
-	g.Expect(controllerPodName).ShouldNot(BeEmpty())
+	if len(podNames) == 0 {
+		return "", fmt.Errorf("no pods found")
+	}
+	return podNames[0], nil
+}
+
+func verifyControllerUp(g Gomega, managerPodLabel string) {
+	controllerPodName, err := getControllerPodName()
+	g.Expect(err).ShouldNot(HaveOccurred())
 
 	// Validate pod status
-	cmd = exec.Command(helper.GetPlatformTool(), "get",
+	cmd := exec.Command(helper.GetPlatformTool(), "get",
 		"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
 		"-n", _namespace,
 	)
@@ -243,8 +255,19 @@ func verifyControllerUp(g Gomega, managerPodLabel string) {
 	g.Expect(string(status)).Should(Equal("Running"), fmt.Sprintf("controller pod in %s status", status))
 }
 
-func getPodLogs(ns string, label string) string {
-	cmd := exec.Command(helper.GetPlatformTool(), "logs", "--all-containers", "-l", label, "-n", ns)
+func getPodLogs(ns string, podName string, label string) string {
+	opts := []string{
+		"-n", ns,
+		"logs",
+		"--all-containers",
+		"--since-time", _start.Format(time.RFC3339),
+	}
+	if podName != "" {
+		opts = append(opts, podName)
+	} else if label != "" {
+		opts = append(opts, "-l", label)
+	}
+	cmd := exec.Command(helper.GetPlatformTool(), opts...)
 	output, _ := helper.Run(cmd)
 	return string(output)
 }
@@ -257,7 +280,13 @@ func describePod(ns string, label string) string {
 
 func fetchOperatorLogs(managerPodLabel string, raw bool) func() string {
 	return func() string {
-		logs := getPodLogs(_namespace, managerPodLabel)
+		var logs string
+		controllerPodName, err := getControllerPodName()
+		if err != nil {
+			logs = fmt.Sprintf("Failed to get controller pod name: %v", err)
+		} else {
+			logs = getPodLogs(_namespace, controllerPodName, managerPodLabel)
+		}
 		if raw {
 			return logs
 		}
@@ -267,7 +296,7 @@ func fetchOperatorLogs(managerPodLabel string, raw bool) func() string {
 
 func fetchOperandLogs(ns string, crLabel string, raw bool) func() string {
 	return func() string {
-		logs := getPodLogs(ns, crLabel)
+		logs := getPodLogs(ns, "", crLabel)
 		if raw {
 			return logs
 		}

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -184,8 +184,8 @@ func installOperatorWithMakeDeploy(withOlm bool) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
-	_start = time.Now()
 	//runs *only* on process #1
+	_start = time.Now()
 	fmt.Fprintln(GinkgoWriter, "isOpenshift:", helper.IsOpenShift())
 
 	if operatorManifest := os.Getenv("OPERATOR_MANIFEST"); operatorManifest != "" {


### PR DESCRIPTION
## Description

Follow-up to #1650 to help the SL team understand what's going on..

## Which issue(s) does this PR fix or relate to

- Relates to https://issues.redhat.com/browse/RHDHBUGS-2050

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Enhance the E2E test suite to always capture and display operator logs at the end of the run

Enhancements:
- Record test start time to enable time-based log retrieval
- Defer operator uninstallation and print operator logs in the SynchronizedAfterSuite
- Extract getControllerPodName helper and refactor verifyControllerUp to use it
- Refactor getPodLogs to accept optional pod name or label and include a --since-time filter
- Update fetchOperatorLogs and fetchOperandLogs to leverage the new log retrieval logic and handle errors