### PR TITLE
Revert "[release-1.8] feat: bumping orchestrator plugins to 1.8.10 (#…

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -45,7 +45,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2026-04-14T18:37:58Z"
+    createdAt: "2026-03-30T15:48:46Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.8
-    createdAt: "2026-04-14T18:37:59Z"
+    createdAt: "2026-03-30T15:48:45Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -357,8 +357,8 @@ data:
     \   includes:\n#      - dynamic-plugins.default.yaml\n#    plugins: []\n#---\napiVersion:
     v1\nkind: ConfigMap\nmetadata:\n  name: default-dynamic-plugins\ndata:\n  dynamic-plugins.yaml:
     |\n    includes:\n      - dynamic-plugins.default.yaml\n    plugins:\n      -
-    disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator@1.8.10\"\n
-    \       integrity: sha512-Tlqs2s4WuzM0QQTvgpIxSj0YPA5Lhr0ahMrEXwu0NRnlehNjJjl6NCZObjKATftcOmYRzBlMaC4JMvTOWNFDlA==\n
+    disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator@1.8.9\"\n
+    \       integrity: sha512-k9r4xEfy3a5En1DTBZkzjhbUVFfbP8Pb+/uCkTXwqqwDJaM2ZzPMzaMj4x65XBnpKTdEZJA0rf/mFMFnfM8I6w==\n
     \       pluginConfig:\n          dynamicPlugins:\n              frontend:\n                red-hat-developer-hub.backstage-plugin-orchestrator:\n
     \                 appIcons:\n                    - importName: OrchestratorIcon\n
     \                     name: orchestratorIcon\n                  dynamicRoutes:\n
@@ -371,18 +371,18 @@ data:
     OrchestratorCatalogTab\n                      config:\n                        layout:\n
     \                         gridColumn: '1 / -1'\n                          if:\n
     \                           anyOf:\n                              - IsOrchestratorCatalogTabAvailable\n
-    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.10\"\n
-    \       integrity: sha512-dRozMLDbj7AYgX4StT53rQ7OqnSx7gn4Js4z/1eZoPAuFm1T/4zwjoOWGJxmmNNPH1pFpeopT8Kc3VVVsWrYeA==\n
+    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.9\"\n
+    \       integrity: sha512-V6Css2y21le4SrMj1tpupppjSkvaZcfvfF9sLoknUnFLCCYkKCH21Fpk2BxA1MMRpVXTUjUJ8lTwYAdrrxBEjg==\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service\n        dependencies:\n
-    \         - ref: sonataflow\n      - disabled: true\n        package: \"@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.10\"\n
-    \       integrity: sha512-jwkwh4sK9jEjbxj6VH/Cr7BAu0nTN2BtLqmeGQWXHwX51U6Vt0hurYi1cHZyD2qPhDRFxZ3rUzWdbKlwNPAvjw==\n
+    \         - ref: sonataflow\n      - disabled: true\n        package: \"@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.9\"\n
+    \       integrity: sha512-VRM/RvqQUemJLBdwm3nYwn2pSTUumZ1YEaHhgh4ELTiuVy2KQcyZCN9cSOCUswjHldmuPyT8dyfGQvSriGNS8Q==\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service               \n
-    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-form-widgets@1.8.10\"\n
-    \       integrity: sha512-BGnPNkd2JZ8hIrkZ8+/C1RSH1PA7DT8SPqkV1MsrRRONYSJZ/xcVNFb2HWo3BtIjYV3pbASm+vysuBYyxilQog==\n
+    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-form-widgets@1.8.9\"\n
+    \       integrity: sha512-fWlawBQUenXQXBUPe04mrIFPhNE05f1aVRJXXFS0FT0doo8X4vijmEeZf4Qm3b1Owgup8E6HHKQr3a94lBrNew==\n
     \       pluginConfig:\n          dynamicPlugins:\n            frontend:\n              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets:
-    { }\n"
+    { }"
   route.yaml: |-
     apiVersion: route.openshift.io/v1
     kind: Route

--- a/config/profile/rhdh/default-config/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/dynamic-plugins.yaml
@@ -30,8 +30,8 @@ data:
       - dynamic-plugins.default.yaml
     plugins:
       - disabled: true
-        package: "@redhat/backstage-plugin-orchestrator@1.8.10"
-        integrity: sha512-Tlqs2s4WuzM0QQTvgpIxSj0YPA5Lhr0ahMrEXwu0NRnlehNjJjl6NCZObjKATftcOmYRzBlMaC4JMvTOWNFDlA==
+        package: "@redhat/backstage-plugin-orchestrator@1.8.9"
+        integrity: sha512-k9r4xEfy3a5En1DTBZkzjhbUVFfbP8Pb+/uCkTXwqqwDJaM2ZzPMzaMj4x65XBnpKTdEZJA0rf/mFMFnfM8I6w==
         pluginConfig:
           dynamicPlugins:
               frontend:
@@ -59,8 +59,8 @@ data:
                             anyOf:
                               - IsOrchestratorCatalogTabAvailable
       - disabled: true
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.10"
-        integrity: sha512-dRozMLDbj7AYgX4StT53rQ7OqnSx7gn4Js4z/1eZoPAuFm1T/4zwjoOWGJxmmNNPH1pFpeopT8Kc3VVVsWrYeA==
+        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.9"
+        integrity: sha512-V6Css2y21le4SrMj1tpupppjSkvaZcfvfF9sLoknUnFLCCYkKCH21Fpk2BxA1MMRpVXTUjUJ8lTwYAdrrxBEjg==
         pluginConfig:
           orchestrator:
             dataIndexService:
@@ -68,15 +68,15 @@ data:
         dependencies:
           - ref: sonataflow
       - disabled: true
-        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.10"
-        integrity: sha512-jwkwh4sK9jEjbxj6VH/Cr7BAu0nTN2BtLqmeGQWXHwX51U6Vt0hurYi1cHZyD2qPhDRFxZ3rUzWdbKlwNPAvjw==
+        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.9"
+        integrity: sha512-VRM/RvqQUemJLBdwm3nYwn2pSTUumZ1YEaHhgh4ELTiuVy2KQcyZCN9cSOCUswjHldmuPyT8dyfGQvSriGNS8Q==
         pluginConfig:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service               
       - disabled: true
-        package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.8.10"
-        integrity: sha512-BGnPNkd2JZ8hIrkZ8+/C1RSH1PA7DT8SPqkV1MsrRRONYSJZ/xcVNFb2HWo3BtIjYV3pbASm+vysuBYyxilQog==
+        package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.8.9"
+        integrity: sha512-fWlawBQUenXQXBUPe04mrIFPhNE05f1aVRJXXFS0FT0doo8X4vijmEeZf4Qm3b1Owgup8E6HHKQr3a94lBrNew==
         pluginConfig:
           dynamicPlugins:
             frontend:

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -2473,8 +2473,8 @@ data:
     \   includes:\n#      - dynamic-plugins.default.yaml\n#    plugins: []\n#---\napiVersion:
     v1\nkind: ConfigMap\nmetadata:\n  name: default-dynamic-plugins\ndata:\n  dynamic-plugins.yaml:
     |\n    includes:\n      - dynamic-plugins.default.yaml\n    plugins:\n      -
-    disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator@1.8.10\"\n
-    \       integrity: sha512-Tlqs2s4WuzM0QQTvgpIxSj0YPA5Lhr0ahMrEXwu0NRnlehNjJjl6NCZObjKATftcOmYRzBlMaC4JMvTOWNFDlA==\n
+    disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator@1.8.9\"\n
+    \       integrity: sha512-k9r4xEfy3a5En1DTBZkzjhbUVFfbP8Pb+/uCkTXwqqwDJaM2ZzPMzaMj4x65XBnpKTdEZJA0rf/mFMFnfM8I6w==\n
     \       pluginConfig:\n          dynamicPlugins:\n              frontend:\n                red-hat-developer-hub.backstage-plugin-orchestrator:\n
     \                 appIcons:\n                    - importName: OrchestratorIcon\n
     \                     name: orchestratorIcon\n                  dynamicRoutes:\n
@@ -2487,18 +2487,18 @@ data:
     OrchestratorCatalogTab\n                      config:\n                        layout:\n
     \                         gridColumn: '1 / -1'\n                          if:\n
     \                           anyOf:\n                              - IsOrchestratorCatalogTabAvailable\n
-    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.10\"\n
-    \       integrity: sha512-dRozMLDbj7AYgX4StT53rQ7OqnSx7gn4Js4z/1eZoPAuFm1T/4zwjoOWGJxmmNNPH1pFpeopT8Kc3VVVsWrYeA==\n
+    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.9\"\n
+    \       integrity: sha512-V6Css2y21le4SrMj1tpupppjSkvaZcfvfF9sLoknUnFLCCYkKCH21Fpk2BxA1MMRpVXTUjUJ8lTwYAdrrxBEjg==\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service\n        dependencies:\n
-    \         - ref: sonataflow\n      - disabled: true\n        package: \"@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.10\"\n
-    \       integrity: sha512-jwkwh4sK9jEjbxj6VH/Cr7BAu0nTN2BtLqmeGQWXHwX51U6Vt0hurYi1cHZyD2qPhDRFxZ3rUzWdbKlwNPAvjw==\n
+    \         - ref: sonataflow\n      - disabled: true\n        package: \"@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.9\"\n
+    \       integrity: sha512-VRM/RvqQUemJLBdwm3nYwn2pSTUumZ1YEaHhgh4ELTiuVy2KQcyZCN9cSOCUswjHldmuPyT8dyfGQvSriGNS8Q==\n
     \       pluginConfig:\n          orchestrator:\n            dataIndexService:\n
     \             url: http://sonataflow-platform-data-index-service               \n
-    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-form-widgets@1.8.10\"\n
-    \       integrity: sha512-BGnPNkd2JZ8hIrkZ8+/C1RSH1PA7DT8SPqkV1MsrRRONYSJZ/xcVNFb2HWo3BtIjYV3pbASm+vysuBYyxilQog==\n
+    \     - disabled: true\n        package: \"@redhat/backstage-plugin-orchestrator-form-widgets@1.8.9\"\n
+    \       integrity: sha512-fWlawBQUenXQXBUPe04mrIFPhNE05f1aVRJXXFS0FT0doo8X4vijmEeZf4Qm3b1Owgup8E6HHKQr3a94lBrNew==\n
     \       pluginConfig:\n          dynamicPlugins:\n            frontend:\n              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets:
-    { }\n"
+    { }"
   route.yaml: |-
     apiVersion: route.openshift.io/v1
     kind: Route

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -68,7 +68,7 @@ This method has similar usage and cautions as the RHDH Helper Utility.
 
 ### Installing the Orchestrator Plugin
 
-The orchestrator plugin (as of v1.8.10) consists of four dynamic plugins:
+The orchestrator plugin (as of v1.8.9) consists of four dynamic plugins:
 - orchestrator-backend
 - orchestrator-frontend
 - orchestrator-scaffolder-backend-module
@@ -80,15 +80,15 @@ To enable the orchestrator plugin, you should refer the dynamic plugins ConfigMa
     includes:
       - dynamic-plugins.default.yaml
     plugins:
-       - package: "@redhat/backstage-plugin-orchestrator@1.8.10"
+       - package: "@redhat/backstage-plugin-orchestrator@1.8.9"
          disabled: false
-       - package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.10"
+       - package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.9"
          disabled: false
          dependencies:
             - ref: sonataflow
-       - package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.10"
+       - package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.9"
          disabled: false
-       - package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.8.10"
+       - package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.8.9"
          disabled: false  
 ```
 

--- a/examples/orchestrator-cicd.yaml
+++ b/examples/orchestrator-cicd.yaml
@@ -8,14 +8,14 @@ data:
       - dynamic-plugins.default.yaml
     plugins:
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator@1.8.10"
+        package: "@redhat/backstage-plugin-orchestrator@1.8.9"
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.10"
+        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.9"
         dependencies:
           - ref: sonataflow
-      - package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.10"
+      - package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.9"
         disabled: false
-      - package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.8.10"
+      - package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.8.9"
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-community-plugin-redhat-argocd
         disabled: false

--- a/examples/orchestrator.yaml
+++ b/examples/orchestrator.yaml
@@ -5,15 +5,15 @@ metadata:
 data:
   dynamic-plugins.yaml: |
     plugins:
-      - package: "@redhat/backstage-plugin-orchestrator@1.8.10"
+      - package: "@redhat/backstage-plugin-orchestrator@1.8.9"
         disabled: false
-      - package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.10"
+      - package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.8.9"
         disabled: false
         dependencies:
           - ref: sonataflow
-      - package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.10"
+      - package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.8.9"
         disabled: false
-      - package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.8.10"
+      - package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.8.9"
         disabled: false
     # Enable Bulk import plugins.
 #      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic


### PR DESCRIPTION
…2646)"

This reverts commit ae1c02603bcb2e817a132c3a0b2cc1201679678f.

There will be another orchestrator plugin release which will most likely be 1.8.11 and that one should be used instead.

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
