### PR TITLE
enable cache label filter with environment variable

### DIFF
--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.10
-    createdAt: "2026-04-26T17:54:47Z"
+    createdAt: "2026-04-30T16:19:49Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,8 +65,8 @@ func main() {
 		"If set, the metrics endpoint is served securely over HTTPS and requires authentication and authorization.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	flag.BoolVar(&enableCacheLabelFilter, "enable-cache-label-filter", false,
-		"If set, the cache will only store Secrets and ConfigMaps with the label 'rhdh.redhat.com/external-config=true'. This reduces memory consumption.")
+	flag.BoolVar(&enableCacheLabelFilter, "enable-cache-label-filter", os.Getenv("ENABLE_CACHE_LABEL_FILTER") == "true",
+		"If set, the cache will only store Secrets and ConfigMaps with the label 'rhdh.redhat.com/external-config=true'. This reduces memory consumption. Can also be set via ENABLE_CACHE_LABEL_FILTER env var.")
 
 	opts := zap.Options{
 		Development: true,

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -86,11 +86,27 @@ This allows the operator to only cache Secrets and ConfigMaps that are explicitl
 
 #### Configuration
 
-Cache-level label filtering can be enabled through the `--enable-cache-label-filter` command-line flag. When enabled, the manager's cache is configured to only store Secrets and ConfigMaps that have the label `rhdh.redhat.com/external-config=true`. This happens at the cache initialization level, preventing unwanted resources from ever being loaded into memory, rather than just filtering events after caching.
+Cache-level label filtering can be enabled through:
+* `ENABLE_CACHE_LABEL_FILTER=true` environment variable
+* `--enable-cache-label-filter` command-line flag.
+
+When enabled, the manager's cache is configured to only store Secrets and ConfigMaps that have the label `rhdh.redhat.com/external-config=true`. This happens at the cache initialization level, preventing unwanted resources from ever being loaded into memory, rather than just filtering events after caching.
 
 **For OLM-based deployments:**
 
-Edit the Subscription or CSV to add the argument:
+**Option 1:**
+Edit the Subscription to add the environment variable:
+
+```yaml
+spec:
+  config:
+    env:
+      - name: "ENABLE_CACHE_LABEL_FILTER"
+        value: "true"
+```
+
+**Option 2:**
+Edit the CSV to add the argument:
 ```yaml
 spec:
   template:


### PR DESCRIPTION
## Description

Enable cache label filter with ENABLE_CACHE_LABEL_FILTER env variable

## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHDHBUGS-2940

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
- On OLM/OCP: modify operator subscription adding:
```
spec:
  config:
    env:
      - name: "ENABLE_CACHE_LABEL_FILTER"
        value: "true"
```
- Check 'manager' container log, it should contain: "INFO    setup    Enabling cache label filter for Secrets and ConfigMaps"