### PR TITLE
chore(lightspeed): use Red Hat plugins with inherit function to handle the references

### DIFF
--- a/config/profile/rhdh/default-config/flavours/lightspeed/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/dynamic-plugins.yaml
@@ -6,7 +6,7 @@ data:
   dynamic-plugins.yaml: |
     plugins:
       # Lightspeed Plugins
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.2.1
+      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}'
         disabled: false
         pluginConfig:
           dynamicPlugins:
@@ -33,5 +33,5 @@ data:
                     config:
                       id: lightspeed
                       priority: 100
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.2.1
+      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}'
         disabled: false


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

Uses Red Hat lightspeed plugins with the `{{inherit}}` plugin installer function to handle matching the current 1.10 references. See [orchestrator](https://github.com/redhat-developer/rhdh-operator/blob/86fb18deb29ac8661dfdbe02100bd40e82ad37da/config/profile/rhdh/default-config/flavours/orchestrator/dynamic-plugins.yaml#L7-L17).

## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHDHBUGS-3030

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
