### PR TITLE
(chore): update lightspeed to use inherit, update catalog index to 1.10 image

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2026-04-26T17:54:44Z"
+    createdAt: "2026-05-01T17:35:49Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.10
-    createdAt: "2026-04-30T16:19:49Z"
+    createdAt: "2026-05-01T17:35:47Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-default-config_v1_configmap.yaml
@@ -228,7 +228,7 @@ data:
                   value: "40000000"
                 # CATALOG_INDEX_IMAGE will be replaced by the value of the `RELATED_IMAGE_catalog_index` env var, if set
                 - name: CATALOG_INDEX_IMAGE
-                  value: "quay.io/rhdh/plugin-catalog-index:1.9"
+                  value: "quay.io/rhdh/plugin-catalog-index:1.10"
                 - name: CATALOG_ENTITIES_EXTRACT_DIR
                   value: '/extensions'
               volumeMounts:

--- a/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
@@ -303,7 +303,7 @@ data:
       dynamic-plugins.yaml: |
         plugins:
           # Lightspeed Plugins
-          - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.2.1
+          - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}
             disabled: false
             pluginConfig:
               dynamicPlugins:
@@ -330,7 +330,7 @@ data:
                         config:
                           id: lightspeed
                           priority: 100
-          - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.2.1
+          - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}
             disabled: false
   metadata.yaml: |
     # Lightspeed (AI) flavour metadata

--- a/config/profile/rhdh/default-config/deployment.yaml
+++ b/config/profile/rhdh/default-config/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               value: "40000000"
             # CATALOG_INDEX_IMAGE will be replaced by the value of the `RELATED_IMAGE_catalog_index` env var, if set
             - name: CATALOG_INDEX_IMAGE
-              value: "quay.io/rhdh/plugin-catalog-index:1.9"
+              value: "quay.io/rhdh/plugin-catalog-index:1.10"
             - name: CATALOG_ENTITIES_EXTRACT_DIR
               value: '/extensions'
           volumeMounts:

--- a/config/profile/rhdh/default-config/flavours/lightspeed/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/dynamic-plugins.yaml
@@ -6,7 +6,7 @@ data:
   dynamic-plugins.yaml: |
     plugins:
       # Lightspeed Plugins
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.2.1
+      - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}
         disabled: false
         pluginConfig:
           dynamicPlugins:
@@ -33,5 +33,5 @@ data:
                     config:
                       id: lightspeed
                       priority: 100
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.2.1
+      - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}
         disabled: false

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -2811,7 +2811,7 @@ data:
                   value: "40000000"
                 # CATALOG_INDEX_IMAGE will be replaced by the value of the `RELATED_IMAGE_catalog_index` env var, if set
                 - name: CATALOG_INDEX_IMAGE
-                  value: "quay.io/rhdh/plugin-catalog-index:1.9"
+                  value: "quay.io/rhdh/plugin-catalog-index:1.10"
                 - name: CATALOG_ENTITIES_EXTRACT_DIR
                   value: '/extensions'
               volumeMounts:
@@ -3325,7 +3325,7 @@ data:
       dynamic-plugins.yaml: |
         plugins:
           # Lightspeed Plugins
-          - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.2.1
+          - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}
             disabled: false
             pluginConfig:
               dynamicPlugins:
@@ -3352,7 +3352,7 @@ data:
                         config:
                           id: lightspeed
                           priority: 100
-          - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.2.1
+          - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}
             disabled: false
   metadata.yaml: |
     # Lightspeed (AI) flavour metadata


### PR DESCRIPTION

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
- Updates Lightspeed plugins to use `{{inherit}}`
- Bumps catalog index image to `1.10`

<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHIDP-13354

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
