### PR TITLE
(fix): add annotation for skipping reconciling for resources

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2026-05-04T14:41:36Z"
+    createdAt: "2026-05-05T14:55:53Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.10
-    createdAt: "2026-05-04T14:41:38Z"
+    createdAt: "2026-05-05T14:55:51Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/docs/lightspeed.md
+++ b/docs/lightspeed.md
@@ -91,6 +91,36 @@ spec:
 
 Ensure the secret contains the necessary authentication keys for AI service access.
 
+#### Preserving Manual Changes To Generated Configs
+
+After the first deployment, you can preserve manual changes to operator-created Lightspeed ConfigMaps by annotating the live object with `rhdh.redhat.com/prevent-overwrite`.
+
+This is useful when you want the operator to create the initial Lightspeed resources for you, and then stop overwriting later edits that you make directly in the cluster. Common examples include the generated `llama-stack-config`, `lightspeed-stack-config`, and `rhdh-profile` ConfigMaps.
+
+Example:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lightspeed-stack-config
+  annotations:
+    rhdh.redhat.com/prevent-overwrite: "true"
+```
+
+Accepted values:
+
+- `true` in any letter case enables the behavior, for example `true`, `True`, or `TRUE`
+- Any other value, including `false` or an empty string, is treated as unset and the operator will continue reconciling the resource
+
+Behavior notes:
+
+- The annotation is checked on the existing live resource after it has already been created by the operator
+- When set to `true`, the operator skips future apply updates for that resource so your manual changes are preserved
+- This does not transfer ownership of the resource away from the `Backstage` CR
+- If the `Backstage` CR is deleted, owned resources can still be deleted as part of normal cleanup
+- Remove the annotation if you want the operator to resume applying updates
+
 #### UI Customization
 
 The Lightspeed chat interface appears as:

--- a/internal/controller/backstage_controller.go
+++ b/internal/controller/backstage_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/redhat-developer/rhdh-operator/pkg/platform"
 
@@ -177,6 +178,19 @@ func (r *BackstageReconciler) applyPayload(ctx context.Context, obj client.Objec
 		} else {
 			lg.V(1).Info("create object ", objDispKind(obj, r.Scheme), obj.GetName())
 		}
+		return nil
+	}
+
+	live, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("failed to deep-copy object %s as client.Object", obj.GetName())
+	}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(obj), live); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get object for prevent-overwrite check: %w", err)
+		}
+	} else if annotations := live.GetAnnotations(); annotations != nil && strings.EqualFold(annotations[model.PreventOverwriteAnnotation], "true") {
+		lg.V(1).Info("skipping apply for prevent-overwrite object", "kind", objDispKind(obj, r.Scheme), "name", obj.GetName(), "namespace", obj.GetNamespace())
 		return nil
 	}
 

--- a/internal/controller/backstage_controller_test.go
+++ b/internal/controller/backstage_controller_test.go
@@ -5,11 +5,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/redhat-developer/rhdh-operator/pkg/model"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -78,6 +83,180 @@ func TestBackstageReconciler_tryToDelete(t *testing.T) {
 			} else {
 				assert.NoError(t, err, "expected no error but got one")
 			}
+		})
+	}
+}
+
+type fakeApplyClient struct {
+	client.Client
+	getFunc   func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error
+	patchFunc func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
+}
+
+func (f *fakeApplyClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+	if f.getFunc == nil {
+		return fmt.Errorf("unexpected Get call")
+	}
+	return f.getFunc(ctx, key, obj, opts...)
+}
+
+func (f *fakeApplyClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if f.patchFunc == nil {
+		return fmt.Errorf("unexpected Patch call")
+	}
+	return f.patchFunc(ctx, obj, patch, opts...)
+}
+
+func TestBackstageReconciler_applyPayload_preventOverwrite(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	baseObj := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-configmap",
+			Namespace: "my-ns",
+		},
+	}
+
+	tests := []struct {
+		name               string
+		desiredAnnotations map[string]string
+		getFunc            func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error
+		patchFunc          func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
+		patchCalled        bool
+		wantErr            bool
+		wantErrContains    string
+	}{
+		{
+			name: "skips apply when prevent-overwrite annotation is present",
+			getFunc: func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				obj.SetAnnotations(map[string]string{model.PreventOverwriteAnnotation: "true"})
+				return nil
+			},
+			patchCalled: false,
+			wantErr:     false,
+		},
+		{
+			name: "skips apply when prevent-overwrite annotation is capitalized True",
+			getFunc: func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				obj.SetAnnotations(map[string]string{model.PreventOverwriteAnnotation: "True"})
+				return nil
+			},
+			patchCalled: false,
+			wantErr:     false,
+		},
+		{
+			name: "proceeds with apply when prevent-overwrite annotation is false",
+			getFunc: func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				obj.SetAnnotations(map[string]string{model.PreventOverwriteAnnotation: "false"})
+				return nil
+			},
+			patchCalled: true,
+			wantErr:     false,
+		},
+		{
+			name: "proceeds with apply when prevent-overwrite annotation is empty",
+			getFunc: func(_ context.Context, _ types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+				obj.SetAnnotations(map[string]string{model.PreventOverwriteAnnotation: ""})
+				return nil
+			},
+			patchCalled: true,
+			wantErr:     false,
+		},
+		{
+			name: "proceeds with apply when annotation is absent",
+			getFunc: func(_ context.Context, _ types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return nil
+			},
+			patchCalled: true,
+			wantErr:     false,
+		},
+		{
+			name:               "proceeds with apply when only desired object has prevent-overwrite annotation",
+			desiredAnnotations: map[string]string{model.PreventOverwriteAnnotation: "true"},
+			getFunc: func(_ context.Context, _ types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return apierrors.NewNotFound(
+					schema.GroupResource{Group: "", Resource: "configmaps"},
+					"my-configmap",
+				)
+			},
+			patchCalled: true,
+			wantErr:     false,
+		},
+		{
+			name: "proceeds with apply when object does not exist yet",
+			getFunc: func(_ context.Context, _ types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return apierrors.NewNotFound(
+					schema.GroupResource{Group: "", Resource: "configmaps"},
+					"my-configmap",
+				)
+			},
+			patchCalled: true,
+			wantErr:     false,
+		},
+		{
+			name: "returns error on transient Get failure",
+			getFunc: func(_ context.Context, _ types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return fmt.Errorf("transient API timeout")
+			},
+			patchCalled:     false,
+			wantErr:         true,
+			wantErrContains: "failed to get object for prevent-overwrite check",
+		},
+		{
+			name: "returns error when apply patch fails",
+			getFunc: func(_ context.Context, _ types.NamespacedName, _ client.Object, _ ...client.GetOption) error {
+				return nil
+			},
+			patchFunc: func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return fmt.Errorf("server-side apply failed")
+			},
+			patchCalled:     true,
+			wantErr:         true,
+			wantErrContains: "failed to apply object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patched := false
+			patchFunc := tt.patchFunc
+			if patchFunc == nil {
+				patchFunc = func(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					patched = true
+					return nil
+				}
+			} else {
+				wrappedPatchFunc := patchFunc
+				patchFunc = func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					patched = true
+					return wrappedPatchFunc(ctx, obj, patch, opts...)
+				}
+			}
+
+			r := &BackstageReconciler{
+				Client: &fakeApplyClient{
+					getFunc: tt.getFunc,
+					patchFunc: patchFunc,
+				},
+				Scheme: scheme,
+			}
+			obj := baseObj.DeepCopy()
+			if tt.desiredAnnotations != nil {
+				obj.SetAnnotations(tt.desiredAnnotations)
+			}
+			err := r.applyPayload(context.TODO(), obj, false)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrContains != "" {
+					assert.ErrorContains(t, err, tt.wantErrContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.patchCalled, patched, "unexpected patch call state")
 		})
 	}
 }

--- a/pkg/model/runtime.go
+++ b/pkg/model/runtime.go
@@ -31,6 +31,7 @@ const DefaultMountPathAnnotation = "rhdh.redhat.com/mount-path"
 const DefaultSubPathAnnotation = "rhdh.redhat.com/sub-path"
 const ContainersAnnotation = "rhdh.redhat.com/containers"
 const SourceAnnotation = "rhdh.redhat.com/source"
+const PreventOverwriteAnnotation = "rhdh.redhat.com/prevent-overwrite"
 
 // Backstage configuration scaffolding with empty BackstageObjects.
 // There are all possible objects for configuration


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
- In the RHDH Helm chart, users of Lightspeed are able to provide their own copies of the configuration files, this is important because for some things (i.e. using postgres instead of sqlite, adding MCP servers) you need to edit the `lightspeed-stack.yaml` config file.
- The Lightspeed flavour had these config files managed by the Operator, and were being overwritten on reconciliation. This change adds a quick fix for that by introducing an annotation to skips the reconciliation if users want it to.
- The resources will still be managed by the Operator in terms of deletion/cleanup, and this will be reflected in the Lightspeed RHDH documentation, and a blurb has been added to `lightspeed.md` in this PR.
 
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
