### PR TITLE
fix: sort map keys to prevent non-deterministic pod spec diffs [RHDHBUGS-3084]

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -458,8 +458,8 @@ The ConfigMap key/value defines the file name and content, and this app-config w
 --config /my/path/my-app-config.yaml
 ```
 
-**Note**: It is possible to define several **app-config** files inside one ConfigMap (even if there are no visible reasons for it) but since it is a Map, the order of how they are applied is not guaranteed. 
-On the other hand, Backstage application merges the chain of **app-config** files from first to last, so order is important. Taking this into account, keeping several **app-config** files inside one ConfigMap is **NOT recommended**. For this case consider defining several one-entry ConfigMaps instead.
+**Note**: It is possible to define several **app-config** files inside one ConfigMap, but the keys are sorted alphabetically to ensure a deterministic order in the pod spec across reconciliations (otherwise, the iteration order would not be guaranteed). This may not match the intended merge order.
+Since Backstage merges the chain of **app-config** files from first to last and order matters, keeping several **app-config** files inside one ConfigMap is **NOT recommended**. For this case consider defining several one-entry ConfigMaps instead.
 
 [Includes and Dynamic Data](https://backstage.io/docs/conf/writing/#includes-and-dynamic-data) (including [extra files](#extra-files) and [extra environment variables](#extra-environment-variables)) support configuring additional ConfigMaps and Secrets.
 

--- a/internal/controller/spec_preprocessor.go
+++ b/internal/controller/spec_preprocessor.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/redhat-developer/rhdh-operator/pkg/utils"
 
-	"golang.org/x/exp/maps"
-
 	"k8s.io/client-go/util/retry"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -85,7 +83,7 @@ func (r *BackstageReconciler) preprocessSpec(ctx context.Context, backstage api.
 			if hashingData, err = r.addExtConfig(ctx, cm, backstage.Name, ac.Name, ns, addToWatch(ac), hashingData); err != nil {
 				return result, err
 			}
-			result.AppConfigKeys[ac.Name] = maps.Keys(cm.Data)
+			result.AppConfigKeys[ac.Name] = utils.SortedKeys(cm.Data)
 		}
 	}
 

--- a/pkg/model/appconfig.go
+++ b/pkg/model/appconfig.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/redhat-developer/rhdh-operator/api"
 	"github.com/redhat-developer/rhdh-operator/pkg/model/multiobject"
+	"github.com/redhat-developer/rhdh-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -76,7 +76,7 @@ func (b *AppConfig) updateAndValidate(_ api.Backstage) error {
 		}
 
 		updatePodWithAppConfig(b.model.backstageDeployment, cm.Name,
-			b.model.backstageDeployment.defaultMountPath(), "", true, maps.Keys(cm.Data))
+			b.model.backstageDeployment.defaultMountPath(), "", true, utils.SortedKeys(cm.Data))
 	}
 	return nil
 }

--- a/pkg/model/configmapfiles.go
+++ b/pkg/model/configmapfiles.go
@@ -3,11 +3,11 @@ package model
 import (
 	"fmt"
 
-	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/redhat-developer/rhdh-operator/api"
 	"github.com/redhat-developer/rhdh-operator/pkg/model/multiobject"
+	"github.com/redhat-developer/rhdh-operator/pkg/utils"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -75,7 +75,7 @@ func (p *ConfigMapFiles) updateAndValidate(_ api.Backstage) error {
 			return fmt.Errorf("payload is not ConfigMap kind: %T", item)
 		}
 
-		keys := append(maps.Keys(cm.Data), maps.Keys(cm.BinaryData)...)
+		keys := append(utils.SortedKeys(cm.Data), utils.SortedKeys(cm.BinaryData)...)
 		mountPath, subPath, fileName := p.model.backstageDeployment.getDefConfigMountPath(cm)
 		err := p.model.backstageDeployment.mountFilesFrom(containersFilter{annotation: cm.GetAnnotations()[ContainersAnnotation]}, ConfigMapObjectKind,
 			cm.Name, mountPath, fileName, subPath != "", keys)

--- a/pkg/model/dynamic-plugins.go
+++ b/pkg/model/dynamic-plugins.go
@@ -6,8 +6,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"golang.org/x/exp/maps"
-
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/redhat-developer/rhdh-operator/api"
@@ -107,7 +105,7 @@ func (p *DynamicPlugins) updateAndValidate(backstage api.Backstage) error {
 	}
 	if backstage.Spec.Application == nil || backstage.Spec.Application.DynamicPluginsConfigMapName == "" {
 		if err := p.model.backstageDeployment.mountFilesFrom(containersFilter{names: []string{dynamicPluginInitContainerName}}, ConfigMapObjectKind,
-			p.ConfigMap.Name, initContainer.WorkingDir, DynamicPluginsFile, true, maps.Keys(p.ConfigMap.Data)); err != nil {
+			p.ConfigMap.Name, initContainer.WorkingDir, DynamicPluginsFile, true, utils.SortedKeys(p.ConfigMap.Data)); err != nil {
 			return fmt.Errorf("failed to mount dynamic plugins configMap: %w", err)
 		}
 	}
@@ -143,13 +141,13 @@ func (p *DynamicPlugins) addExternalConfig(spec api.BackstageSpec) error {
 			}
 			p.ConfigMap.Data[DynamicPluginsFile] = mergedData
 			err = p.model.backstageDeployment.mountFilesFrom(containersFilter{names: []string{dynamicPluginInitContainerName}}, ConfigMapObjectKind,
-				p.ConfigMap.Name, initContainer.WorkingDir, DynamicPluginsFile, true, maps.Keys(p.ConfigMap.Data))
+				p.ConfigMap.Name, initContainer.WorkingDir, DynamicPluginsFile, true, utils.SortedKeys(p.ConfigMap.Data))
 			if err != nil {
 				return fmt.Errorf("failed to mount dynamic plugins configMap: %w", err)
 			}
 		} else {
 			err := p.model.backstageDeployment.mountFilesFrom(containersFilter{names: []string{dynamicPluginInitContainerName}}, ConfigMapObjectKind,
-				dp.Name, initContainer.WorkingDir, DynamicPluginsFile, true, maps.Keys(dp.Data))
+				dp.Name, initContainer.WorkingDir, DynamicPluginsFile, true, utils.SortedKeys(dp.Data))
 			if err != nil {
 				return fmt.Errorf("failed to mount dynamic plugins configMap: %w", err)
 			}

--- a/pkg/model/externalconfig.go
+++ b/pkg/model/externalconfig.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"golang.org/x/exp/maps"
+	"github.com/redhat-developer/rhdh-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -46,8 +46,8 @@ type DataObjectKeys struct {
 
 func NewDataObjectKeys(stringData map[string]string, binaryData map[string][]byte) DataObjectKeys {
 	return DataObjectKeys{
-		StringDataKey: maps.Keys(stringData),
-		BinaryDataKey: maps.Keys(binaryData),
+		StringDataKey: utils.SortedKeys(stringData),
+		BinaryDataKey: utils.SortedKeys(binaryData),
 	}
 }
 

--- a/pkg/model/secretfiles.go
+++ b/pkg/model/secretfiles.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/redhat-developer/rhdh-operator/pkg/model/multiobject"
-	"golang.org/x/exp/maps"
+	"github.com/redhat-developer/rhdh-operator/pkg/utils"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -83,7 +83,7 @@ func (p *SecretFiles) updateAndValidate(_ api.Backstage) error {
 			return fmt.Errorf("payload is not Secret kind: %T", item)
 		}
 
-		keys := append(maps.Keys(secret.Data), maps.Keys(secret.StringData)...)
+		keys := append(utils.SortedKeys(secret.Data), utils.SortedKeys(secret.StringData)...)
 		mountPath, subPath, fileName := p.model.backstageDeployment.getDefConfigMountPath(item)
 		err := p.model.backstageDeployment.mountFilesFrom(containersFilter{annotation: item.GetAnnotations()[ContainersAnnotation]}, SecretObjectKind,
 			item.GetName(), mountPath, fileName, subPath != "", keys)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -13,8 +13,11 @@ import (
 
 	//"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
+
+	"golang.org/x/exp/maps"
 
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/kustomize/kyaml/yaml/merge2"
@@ -236,6 +239,13 @@ func ToRFC1123Label(str string) string {
 	}
 
 	return name
+}
+
+// SortedKeys returns the keys of a map in sorted order.
+func SortedKeys[M ~map[K]V, K ~string, V any](m M) []K {
+	keys := maps.Keys(m)
+	slices.Sort(keys)
+	return keys
 }
 
 func BoolEnvVar(envvar string, def bool) bool {


### PR DESCRIPTION
## Description

When iterating over multi-file app-config ConfigMaps, we could get different key orderings on each reconciliation. This caused volume mounts and `--config` args to potentially shuffle, making the pod spec not deterministic even without any config changes, causing continuous pod restarts. This was more noticeable when deploying RHDH as a StatefulSet.
This PR ensures a deterministic iteration order by sorting map keys.

## Which issue(s) does this PR fix or relate to

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3084

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer

See the repro steps in https://redhat.atlassian.net/browse/RHDHBUGS-3084