### PR TITLE
fix: use %w for error wrapping and add missing bounds check

### DIFF
--- a/internal/controller/backstage_controller.go
+++ b/internal/controller/backstage_controller.go
@@ -106,7 +106,7 @@ func (r *BackstageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, errorAndStatus(&backstage, "failed to apply ServiceMonitor", err)
 	}
 
-	// This creates array of model objects to be reconsiled
+	// This creates array of model objects to be reconciled
 	bsModel, err := model.InitObjects(ctx, backstage, externalConfig, r.Platform, r.Scheme)
 	if err != nil {
 		return ctrl.Result{}, errorAndStatus(&backstage, "failed to initialize backstage model", err)

--- a/internal/controller/spec_preprocessor.go
+++ b/internal/controller/spec_preprocessor.go
@@ -215,7 +215,7 @@ func (r *BackstageReconciler) checkExternalObject(ctx context.Context, obj clien
 		if _, ok := obj.(*corev1.Secret); ok && k8serrors.IsForbidden(err) {
 			return fmt.Errorf("warning: Secrets GET is forbidden, updating Secrets may not cause Pod recreating")
 		}
-		return fmt.Errorf("failed to get external config from %s: %s", objectName, err)
+		return fmt.Errorf("failed to get external config from %s: %w", objectName, err)
 	}
 	return nil
 }

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -497,7 +497,11 @@ func mergeDeployments(sources []configSource, scheme runtime.Scheme, platformExt
 	}
 
 	if len(objs) == 0 {
-		return nil, fmt.Errorf("no objects found in merged deployment")
+		paths := make([]string, len(sources))
+		for i, s := range sources {
+			paths[i] = s.path
+		}
+		return nil, fmt.Errorf("no objects found after merging deployment sources: %v", paths)
 	}
 	return []client.Object{objs[0]}, nil
 }

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -496,5 +496,8 @@ func mergeDeployments(sources []configSource, scheme runtime.Scheme, platformExt
 		return nil, fmt.Errorf("failed to parse merged deployment: %w", err)
 	}
 
+	if len(objs) == 0 {
+		return nil, fmt.Errorf("no objects found in merged deployment")
+	}
 	return []client.Object{objs[0]}, nil
 }

--- a/pkg/model/runtime.go
+++ b/pkg/model/runtime.go
@@ -138,7 +138,7 @@ func InitObjects(ctx context.Context, backstage api.Backstage, externalConfig Ex
 
 		if objs, err := ReadDefaultConfig(conf, flavours, *scheme, platform.Extension); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
-				return nil, fmt.Errorf("failed to read default value for the key %s, reason: %s", conf.Key, err)
+				return nil, fmt.Errorf("failed to read default value for the key %s, reason: %w", conf.Key, err)
 			}
 		} else if len(objs) > 0 {
 			if obj, err := adjustObject(conf, objs); err != nil {
@@ -155,7 +155,7 @@ func InitObjects(ctx context.Context, backstage api.Backstage, externalConfig Ex
 			// new object to replace default, not merge
 			if objs, err := utils.ReadYamls([]byte(overlay), nil, *scheme); err != nil {
 				if !errors.Is(err, os.ErrNotExist) {
-					return nil, fmt.Errorf("failed to read default value for the key %s, reason: %s", conf.Key, err)
+					return nil, fmt.Errorf("failed to read default value for the key %s, reason: %w", conf.Key, err)
 				}
 			} else {
 				if obj, err := adjustObject(conf, objs); err != nil {
@@ -168,7 +168,7 @@ func InitObjects(ctx context.Context, backstage api.Backstage, externalConfig Ex
 
 		// apply spec and add the object to the model and list
 		if added, err := backstageObject.addToModel(model, backstage); err != nil {
-			return nil, fmt.Errorf("failed to initialize backstage, reason: %s", err)
+			return nil, fmt.Errorf("failed to initialize backstage, reason: %w", err)
 		} else if added {
 			backstageObject.setMetaInfo(backstage, scheme)
 		}
@@ -183,14 +183,14 @@ func InitObjects(ctx context.Context, backstage api.Backstage, externalConfig Ex
 	for _, v := range model.RuntimeObjects {
 		err := v.updateAndValidate(backstage)
 		if err != nil {
-			return nil, fmt.Errorf("failed object validation, reason: %s", err)
+			return nil, fmt.Errorf("failed object validation, reason: %w", err)
 		}
 	}
 
 	// Add objects specified in Backstage CR
 	for _, ecc := range ecs {
 		if err := ecc.addExternalConfig(backstage.Spec); err != nil {
-			return nil, fmt.Errorf("failed to contribute external config, reason: %s", err)
+			return nil, fmt.Errorf("failed to contribute external config, reason: %w", err)
 		}
 	}
 

--- a/pkg/model/runtime.go
+++ b/pkg/model/runtime.go
@@ -155,7 +155,7 @@ func InitObjects(ctx context.Context, backstage api.Backstage, externalConfig Ex
 			// new object to replace default, not merge
 			if objs, err := utils.ReadYamls([]byte(overlay), nil, *scheme); err != nil {
 				if !errors.Is(err, os.ErrNotExist) {
-					return nil, fmt.Errorf("failed to read default value for the key %s, reason: %w", conf.Key, err)
+					return nil, fmt.Errorf("failed to read overlay value for the key %s, reason: %w", conf.Key, err)
 				}
 			} else {
 				if obj, err := adjustObject(conf, objs); err != nil {

--- a/pkg/model/runtime_test.go
+++ b/pkg/model/runtime_test.go
@@ -218,5 +218,5 @@ func TestInvalidObjectKind(t *testing.T) {
 	testObj := createBackstageTest(bs).withDefaultConfig(true).addToDefaultConfig("service.yaml", "invalid-service-type.yaml")
 	_, err := InitObjects(context.TODO(), bs, testObj.externalConfig, platform.Default, testObj.scheme)
 
-	assert.ErrorContains(t, err, "failed to read default value for the key service.yaml")
+	assert.ErrorContains(t, err, "failed to read overlay value for the key service.yaml")
 }


### PR DESCRIPTION
## Summary

This PR solves several small but important error handling and correctness issues across the operator:

- **Broken error wrapping (`%s` -> `%w`):** 6 `fmt.Errorf` calls across `pkg/model/runtime.go` and `internal/controller/spec_preprocessor.go` used `%s` instead of `%w`, which dropped the error chain and broke `errors.Is`/`errors.As` for callers
- **Missing bounds check in `mergeDeployments`:** `pkg/model/deployment.go` accessed `objs[0]` without checking for an empty slice, which could panic and crash the controller. Added a guard consistent with the existing check in `mergeDynamicPlugins`, including source file paths in the error for debuggability
- **Misleading error message for overlay reads:** `pkg/model/runtime.go` reported "failed to read default value" when the error was actually from reading overlay config, sending operators looking in the wrong place during debugging

fixes https://redhat.atlassian.net/browse/RHDHBUGS-3142 

## Test plan
- [x] `make test` passes, all unit and integration tests green