### PR TITLE
chore(lightspeed): use inherit for pluginConfig

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2026-05-04T14:41:36Z"
+    createdAt: "2026-05-14T19:47:31Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.10
-    createdAt: "2026-05-04T14:41:38Z"
+    createdAt: "2026-05-14T19:47:29Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
@@ -322,31 +322,7 @@ data:
           # Lightspeed Plugins
           - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}
             disabled: false
-            pluginConfig:
-              dynamicPlugins:
-                frontend:
-                  red-hat-developer-hub.backstage-plugin-lightspeed:
-                    translationResources:
-                      - importName: lightspeedTranslations
-                        module: Alpha
-                        ref: lightspeedTranslationRef
-                    dynamicRoutes:
-                      - path: /lightspeed
-                        importName: LightspeedPage
-                    mountPoints:
-                      - mountPoint: application/listener
-                        importName: LightspeedFAB
-                      - mountPoint: application/provider
-                        importName: LightspeedDrawerProvider
-                      - mountPoint: application/internal/drawer-state
-                        importName: LightspeedDrawerStateExposer
-                        config:
-                          id: lightspeed
-                      - mountPoint: application/internal/drawer-content
-                        importName: LightspeedChatContainer
-                        config:
-                          id: lightspeed
-                          priority: 100
+
           - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}
             disabled: false
   metadata.yaml: |

--- a/config/profile/rhdh/default-config/flavours/lightspeed/dynamic-plugins.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/dynamic-plugins.yaml
@@ -8,30 +8,6 @@ data:
       # Lightspeed Plugins
       - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}
         disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-lightspeed:
-                translationResources:
-                  - importName: lightspeedTranslations
-                    module: Alpha
-                    ref: lightspeedTranslationRef
-                dynamicRoutes:
-                  - path: /lightspeed
-                    importName: LightspeedPage
-                mountPoints:
-                  - mountPoint: application/listener
-                    importName: LightspeedFAB
-                  - mountPoint: application/provider
-                    importName: LightspeedDrawerProvider
-                  - mountPoint: application/internal/drawer-state
-                    importName: LightspeedDrawerStateExposer
-                    config:
-                      id: lightspeed
-                  - mountPoint: application/internal/drawer-content
-                    importName: LightspeedChatContainer
-                    config:
-                      id: lightspeed
-                      priority: 100
+
       - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}
         disabled: false

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -3344,31 +3344,7 @@ data:
           # Lightspeed Plugins
           - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}
             disabled: false
-            pluginConfig:
-              dynamicPlugins:
-                frontend:
-                  red-hat-developer-hub.backstage-plugin-lightspeed:
-                    translationResources:
-                      - importName: lightspeedTranslations
-                        module: Alpha
-                        ref: lightspeedTranslationRef
-                    dynamicRoutes:
-                      - path: /lightspeed
-                        importName: LightspeedPage
-                    mountPoints:
-                      - mountPoint: application/listener
-                        importName: LightspeedFAB
-                      - mountPoint: application/provider
-                        importName: LightspeedDrawerProvider
-                      - mountPoint: application/internal/drawer-state
-                        importName: LightspeedDrawerStateExposer
-                        config:
-                          id: lightspeed
-                      - mountPoint: application/internal/drawer-content
-                        importName: LightspeedChatContainer
-                        config:
-                          id: lightspeed
-                          priority: 100
+
           - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}
             disabled: false
   metadata.yaml: |


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
- Removes `pluginConfig` and instead relies on `inherit` as the `pluginConfig` has been updated in the DPDY https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog/-/blob/rhdh-1-rhel-9/catalog-index/dynamic-plugins.default.yaml#L907-949
## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
