### PR TITLE
chore(ci): add release-1.10 to nightly E2E test matrices

### DIFF
--- a/.github/workflows/nightly-upgrade-test.yaml
+++ b/.github/workflows/nightly-upgrade-test.yaml
@@ -15,8 +15,10 @@ jobs:
         from_branch:
           - release-1.8
           - release-1.9
+          - release-1.10
         to_branch:
           - main
+          - release-1.10
           - release-1.9
           - release-1.8
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         branch:
           - main
+          - release-1.10
           - release-1.9
           - release-1.8
     name: 'Nightly Tests on ${{ matrix.branch }}'


### PR DESCRIPTION
## Description

Add `release-1.10` to the nightly E2E test matrices, similar to #2171 (which added `release-1.9`).

- Add `release-1.10` to the `branch` matrix in the nightly E2E workflow
- Add `release-1.10` to both `from_branch` and `to_branch` matrices in the nightly upgrade test workflow

## Which issue(s) does this PR fix or relate to

- N/A

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer

- Verify the nightly workflow includes `release-1.10` in the matrix
- Verify the nightly upgrade test workflow includes `release-1.10` in both `from_branch` and `to_branch`
- Invalid upgrade paths (same branch, downgrades) are still automatically skipped by the existing `upgrade-path-checker` step