### PR TITLE
fix(mirror-plugins): prevent OCI URL path prefix stacking when target registry includes a path

### DIFF
--- a/.rhdh/scripts/mirror-plugins.sh
+++ b/.rhdh/scripts/mirror-plugins.sh
@@ -497,7 +497,8 @@ function mirror_catalog_index() {
       . | with_entries(
         .value.registryReference |= (
           if . then
-            . | sub("^[^/]+(/[^/]+)*/(?<last2>[^/]+/[^/]+)$"; $target_reg + "/" + .last2)
+            (try capture("^[^/]+(/[^/]+)*/(?<last2>[^/]+/[^/]+)$") catch null) as $m
+            | if $m then $target_reg + "/" + $m.last2 else . end
           else
             .
           end
@@ -960,7 +961,8 @@ function mirror_plugins_from_dir() {
       . | with_entries(
         .value.registryReference |= (
           if . then
-            . | sub("^[^/]+(/[^/]+)*/(?<last2>[^/]+/[^/]+)$"; $target_reg + "/" + .last2)
+            (try capture("^[^/]+(/[^/]+)*/(?<last2>[^/]+/[^/]+)$") catch null) as $m
+            | if $m then $target_reg + "/" + $m.last2 else . end
           else
             .
           end

--- a/.rhdh/scripts/mirror-plugins.sh
+++ b/.rhdh/scripts/mirror-plugins.sh
@@ -491,13 +491,13 @@ function mirror_catalog_index() {
     infof "Updating plugin registry references in index.json..."
     
     # Use jq to update all registryReference values
-    # Replace the registry domain (first component before /) with target registry
+    # Replace the full registry path (hostname + any path prefix) with target registry,
+    # preserving only the last two path elements (org/image) and tag/digest
     if ! jq --arg target_reg "$target_registry" '
       . | with_entries(
         .value.registryReference |= (
           if . then
-            # Remove everything up to and including first slash, then prepend target registry
-            . | sub("^[^/]+/"; $target_reg + "/")
+            . | sub("^[^/]+(/[^/]+)*/(?<last2>[^/]+/[^/]+)$"; $target_reg + "/" + .last2)
           else
             .
           end
@@ -516,9 +516,10 @@ function mirror_catalog_index() {
     # Update OCI references in dynamic-plugins.default.yaml
     infof "Updating OCI references in dynamic-plugins.default.yaml..."
     if [[ -f "$catalog_data_dir/dynamic-plugins.default.yaml" ]]; then
-      # Replace OCI registry references (preserves path and tag)
-      # Pattern: oci://REGISTRY/PATH:TAG -> oci://NEW_REGISTRY/PATH:TAG
-      sed -i -E "s|oci://[^/]+/|oci://$target_registry/|g" "$catalog_data_dir/dynamic-plugins.default.yaml"
+      # Replace OCI registry references (preserves last two path elements and tag)
+      # Pattern: oci://REGISTRY/org/image:TAG -> oci://NEW_REGISTRY/org/image:TAG
+      # Matches full registry path (hostname + any path prefix) before the last two elements
+      sed -i -E "s|oci://[^/]+(/[^/]+)*(/[^/]+/[^[:space:]\"']+)|oci://$target_registry\2|g" "$catalog_data_dir/dynamic-plugins.default.yaml"
       debugf "Updated OCI references in dynamic-plugins.default.yaml"
     fi
     
@@ -527,7 +528,7 @@ function mirror_catalog_index() {
     local yaml_count=0
     while IFS= read -r yaml_file; do
       if [[ -n "$yaml_file" && -f "$yaml_file" ]]; then
-        sed -i -E "s|oci://[^/]+/|oci://$target_registry/|g" "$yaml_file"
+        sed -i -E "s|oci://[^/]+(/[^/]+)*(/[^/]+/[^[:space:]\"']+)|oci://$target_registry\2|g" "$yaml_file"
         ((yaml_count++)) || true
       fi
     done < <(find "$catalog_data_dir/catalog-entities" -name "*.yaml" -type f 2>/dev/null)
@@ -959,8 +960,7 @@ function mirror_plugins_from_dir() {
       . | with_entries(
         .value.registryReference |= (
           if . then
-            # Remove everything up to and including first slash, then prepend target registry
-            . | sub("^[^/]+/"; $target_reg + "/")
+            . | sub("^[^/]+(/[^/]+)*/(?<last2>[^/]+/[^/]+)$"; $target_reg + "/" + .last2)
           else
             .
           end
@@ -977,7 +977,7 @@ function mirror_plugins_from_dir() {
     # Update OCI references in dynamic-plugins.default.yaml
     infof "Updating OCI references in dynamic-plugins.default.yaml..."
     if [[ -f "$catalog_dir/dynamic-plugins.default.yaml" ]]; then
-      sed -i -E "s|oci://[^/]+/|oci://$TO_REGISTRY/|g" "$catalog_dir/dynamic-plugins.default.yaml"
+      sed -i -E "s|oci://[^/]+(/[^/]+)*(/[^/]+/[^[:space:]\"']+)|oci://$TO_REGISTRY\2|g" "$catalog_dir/dynamic-plugins.default.yaml"
       debugf "Updated OCI references in dynamic-plugins.default.yaml"
     fi
     
@@ -986,7 +986,7 @@ function mirror_plugins_from_dir() {
     local yaml_count=0
     while IFS= read -r yaml_file; do
       if [[ -n "$yaml_file" && -f "$yaml_file" ]]; then
-        sed -i -E "s|oci://[^/]+/|oci://$TO_REGISTRY/|g" "$yaml_file"
+        sed -i -E "s|oci://[^/]+(/[^/]+)*(/[^/]+/[^[:space:]\"']+)|oci://$TO_REGISTRY\2|g" "$yaml_file"
         ((yaml_count++)) || true
       fi
     done < <(find "$catalog_dir/catalog-entities" -name "*.yaml" -type f 2>/dev/null)


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix mirror-plugins OCI rewrite for registries with path prefixes
<code>🐞 Bug fix</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Description
Fixes OCI URL corruption in `mirror-plugins.sh` when the target registry includes a path prefix (e.g., JFrog Artifactory with artifactory.example.com/ocp). The `sed` and `jq` regexes that rewrite OCI URLs in the catalog index only matched the hostname portion (`[^/]+`), treating everything after the first `/` as the image path. When `--to-registry` includes a path prefix, each  re-run of the script stacks the prefix:

  Run 1: oci://artifactory.example.com/ocp/rhdh/plugin-catalog-index:1.9         ✓ correct
  Run 2: oci://artifactory.example.com/ocp/ocp/rhdh/plugin-catalog-index:1.9     ✗ stacked
  Run 3: oci://artifactory.example.com/ocp/ocp/ocp/rhdh/plugin-catalog-index:1.9 ✗ worse

This PR updates all 6 regexes to match the full registry reference (hostname + any path prefix segments) instead of just the hostname, preserving only the last two path elements (org/image) and the tag/digest. The fix is idempotent re-running produces identical output. 

## Which issue(s) does this PR fix or relate to

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3121

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
```bash
  1. Start a local registry with podman:
  podman run -d --name test-registry -p 5555:5000 docker.io/library/registry:2
  curl -s http://localhost:5555/v2/
  
  2. Save both script versions:
  # Buggy version (upstream release-1.9, before fix)
  git show upstream/release-1.9:.rhdh/scripts/mirror-plugins.sh > /tmp/mirror-plugins-buggy.sh
  chmod +x /tmp/mirror-plugins-buggy.sh

  # Fixed version (your working tree with the fix)
  cp .rhdh/scripts/mirror-plugins.sh /tmp/mirror-plugins-fixed.sh
  chmod +x /tmp/mirror-plugins-fixed.sh

  3. Test the BUGGY version:
  # Export catalog index to directory
  bash /tmp/mirror-plugins-buggy.sh \
    --plugin-index oci://registry.access.redhat.com/rhdh/plugin-catalog-index:1.9 \
    --to-dir /tmp/plugins-buggy-test
    
  # Run 1: push from dir to registry with path prefix
  bash /tmp/mirror-plugins-buggy.sh \
    --from-dir /tmp/plugins-buggy-test \
    --to-registry localhost:5555/ocp
    
  # Check — should be correct
  jq 'to_entries[0:3] | .[].value.registryReference' /tmp/plugins-buggy-test/catalog-index/index.json

  # Run 2: same command again
  bash /tmp/mirror-plugins-buggy.sh \
    --from-dir /tmp/plugins-buggy-test \
    --to-registry localhost:5555/ocp
    
  # Check — BUG: /ocp/ocp stacked
  jq 'to_entries[0:3] | .[].value.registryReference' /tmp/plugins-buggy-test/catalog-index/index.json
  grep 'oci://' /tmp/plugins-buggy-test/catalog-index/dynamic-plugins.default.yaml | head -3

  4. Test the FIXED version:
  # Export catalog index to directory
  bash /tmp/mirror-plugins-fixed.sh \
    --plugin-index oci://registry.access.redhat.com/rhdh/plugin-catalog-index:1.9 \
    --to-dir /tmp/plugins-fixed-test
    
  # Run 1
    --from-dir /tmp/plugins-buggy-test \
    --to-registry localhost:5555/ocp

  # Check — should be correct
  jq 'to_entries[0:3] | .[].value.registryReference' /tmp/plugins-buggy-test/catalog-index/index.json

  # Run 2: same command again
  bash /tmp/mirror-plugins-buggy.sh \
    --from-dir /tmp/plugins-buggy-test \
    --to-registry localhost:5555/ocp

  # Check — BUG: /ocp/ocp stacked
  jq 'to_entries[0:3] | .[].value.registryReference' /tmp/plugins-buggy-test/catalog-index/index.json
  grep 'oci://' /tmp/plugins-buggy-test/catalog-index/dynamic-plugins.default.yaml | head -3

  4. Test the FIXED version:
  # Export catalog index to directory
  bash /tmp/mirror-plugins-fixed.sh \
    --plugin-index oci://registry.access.redhat.com/rhdh/plugin-catalog-index:1.9 \
    --to-dir /tmp/plugins-fixed-test

  # Run 1
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json

  # Run 2
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json

  # Run 3
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json
  grep 'oci://' /tmp/plugins-fixed-test/catalog-index/dynamic-plugins.default.yaml | head -3

  5. Cleanup:
  podman stop test-registry && podman rm test-registry
  rm -rf /tmp/plugins-buggy-test /tmp/plugins-fixed-test /tmp/mirror-plugins-buggy.sh /tmp/mirror-plugins-fixed.sh

  The key is localhost:5555/ocp as the target registry — the /ocp path prefix is what triggers the stacking bug on re-runs.
  grep 'oci://' /tmp/plugins-buggy-test/catalog-index/dynamic-plugins.default.yaml | head -3

  4. Test the FIXED version:
  # Export catalog index to directory

  # Run 1
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp
  # Run 1
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json

  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json

    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json


  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json

  # Run 2
  bash /tmp/mirror-plugins-fixed.sh \
  # Run 2
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json
  # Run 2: same command again
  bash /tmp/mirror-plugins-buggy.sh \
    --from-dir /tmp/plugins-buggy-test \
    --to-registry localhost:5555/ocp

  # Check — BUG: /ocp/ocp stacked
  jq 'to_entries[0:3] | .[].value.registryReference' /tmp/plugins-buggy-test/catalog-index/index.json
  grep 'oci://' /tmp/plugins-buggy-test/catalog-index/dynamic-plugins.default.yaml | head -3

  4. Test the FIXED version:
  # Export catalog index to directory
  bash /tmp/mirror-plugins-fixed.sh \
    --plugin-index oci://registry.access.redhat.com/rhdh/plugin-catalog-index:1.9 \
    --to-dir /tmp/plugins-fixed-test

  # Run 1
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json

  # Run 2
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json

  # Run 3
  bash /tmp/mirror-plugins-fixed.sh \
    --from-dir /tmp/plugins-fixed-test \
    --to-registry localhost:5555/ocp

  jq 'to_entries[0:2] | .[].value.registryReference' /tmp/plugins-fixed-test/catalog-index/index.json
  grep 'oci://' /tmp/plugins-fixed-test/catalog-index/dynamic-plugins.default.yaml | head -3

  5. Cleanup:
  podman stop test-registry && podman rm test-registry
  rm -rf /tmp/plugins-buggy-test /tmp/plugins-fixed-test /tmp/mirror-plugins-buggy.sh /tmp/mirror-plugins-fixed.sh
```

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Fix OCI registry rewrite to handle registries that include path prefixes (e.g., Artifactory).
• Make catalog index and YAML OCI rewrites idempotent across repeated script runs.
• Preserve only org/image and tag/digest when retargeting to --to-registry.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["mirror-plugins.sh"] --> B{{"Extract catalog index"}} --> C[("index.json")]
  C --> D{{"Rewrite OCI refs (jq/sed)"}} --> E[("dynamic-plugins + entities")]
  E --> F{{"Rebuild & push index"}} --> G["Target registry"]
  subgraph Legend
    direction LR
    _script["Script"] ~~~ _step{{"Step/Tool"}} ~~~ _file[("File")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Parse and reconstruct refs by splitting (no regex)</b></summary>

- ➕ More robust against edge cases (extra slashes, @digest vs :tag, unusual characters).
- ➕ Easier to reason about idempotency than complex regexes.
- ➖ More bash code and branching; still tricky without a real parser.
- ➖ Must duplicate logic for jq-updated JSON vs sed-updated YAML.

</details>

<details>
<summary><b>2. Use purpose-built tooling (yq/jq-only or small helper program)</b></summary>

- ➕ Can parse YAML/JSON structurally and reduce reliance on sed regex.
- ➕ Easier to test and validate transformations in a typed language.
- ➖ Adds dependency/packaging overhead (especially for a small fix).
- ➖ Potentially out of scope for a targeted bug fix in a script.

</details>

**Recommendation:** Current approach is appropriate for a scoped bash-script fix: updating the jq/sed patterns to match the full registry reference (including optional path prefixes) directly addresses the idempotency bug without introducing new dependencies. If future edge cases emerge (digest formats, unusual repo names), consider refactoring into split/reconstruct logic or a small helper to avoid further regex growth.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>mirror-plugins.sh</strong> <code>Fix idempotent OCI registry rewriting when --to-registry includes a path</code> <code>+11/-11</code></summary>

<br/>

>Fix idempotent OCI registry rewriting when --to-registry includes a path
>
><pre>
>• Updates jq and sed rewrite patterns to match the full registry reference (hostname plus optional path prefix segments) rather than just the hostname. Ensures rewritten OCI references preserve only the last two path elements (org/image) plus tag/digest, preventing path-prefix stacking across repeated runs in both catalog-index mirroring and from-dir rebuild flows.
></pre>
>
><a href='https://github.com/redhat-developer/rhdh-operator/pull/2982/files#diff-16b4c07294140b698552f70fe00da3dc070492b945837c8b3a1438462eab06d3'>.rhdh/scripts/mirror-plugins.sh</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>