### PR TITLE
fix(ci): use dynamic API version in upgrade test

### DIFF
--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -49,6 +49,10 @@ var _ = Describe("Operator upgrade with existing instances", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			EventuallyWithOffset(1, verifyControllerUp, 5*time.Minute, time.Second).WithArguments("app=rhdh-operator").Should(Succeed())
 
+			apiVersion, err := helper.GetBackstageCRDStorageVersion()
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "could not determine Backstage CRD storage version")
+			GinkgoWriter.Printf("Using Backstage CRD API version: %s\n", apiVersion)
+
 			cmd = exec.Command(helper.GetPlatformTool(), "-n", ns, "apply", "-f", "-")
 			stdin, err := cmd.StdinPipe()
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -59,12 +63,12 @@ var _ = Describe("Operator upgrade with existing instances", func() {
 					}
 				}()
 				_, _ = io.WriteString(stdin, fmt.Sprintf(`
-apiVersion: rhdh.redhat.com/v1alpha3
+apiVersion: rhdh.redhat.com/%s
 kind: Backstage
 metadata:
   name: my-backstage-app
   namespace: %s
-`, ns))
+`, apiVersion, ns))
 			}()
 			_, err = helper.Run(cmd)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/tests/helper/helper_backstage.go
+++ b/tests/helper/helper_backstage.go
@@ -90,6 +90,21 @@ func GuestAuth(baseUrl string) (string, error) {
 	return authResponse.BackstageIdentity.Token, nil
 }
 
+// GetBackstageCRDStorageVersion returns the storage API version from the installed Backstage CRD.
+func GetBackstageCRDStorageVersion() (string, error) {
+	cmd := exec.Command(GetPlatformTool(), "get", "crd", "backstages.rhdh.redhat.com",
+		"-o", `jsonpath={.spec.versions[?(@.storage==true)].name}`) // #nosec G204
+	out, err := Run(cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Backstage CRD storage version: %w", err)
+	}
+	version := strings.TrimSpace(string(out))
+	if version == "" {
+		return "", fmt.Errorf("no storage version found in Backstage CRD")
+	}
+	return version, nil
+}
+
 func VerifyBackstagePodStatus(g Gomega, ns string, crName string, expectedStatus string) {
 	cmd := exec.Command("kubectl", "get", "pods",
 		"-l", "rhdh.redhat.com/app=backstage-"+crName,


### PR DESCRIPTION
## Description

The upgrade test hardcoded `rhdh.redhat.com/v1alpha3` when creating the Backstage CR against the "from" operator. Since 1.10+ no longer serves `v1alpha3` (https://github.com/redhat-developer/rhdh-operator/pull/2727), the `1.10 => main` upgrade path fails: https://github.com/redhat-developer/rhdh-operator/actions/runs/27315253434/job/80694281540

This PR queries the installed CRD for its storage version instead, which is always served regardless of the branch.

Will need to be cherry-picked to `release-1.10` as well.

## Which issue(s) does this PR fix or relate to

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3349

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
