### PR TITLE
fix: Updating install-rhdh-catalog-source.sh script to run on ARO Cluster

### DIFF
--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -293,6 +293,7 @@ function ocp_install() {
   debugf "Exposing cluster registry..." >&2
   internal_registry_url="image-registry.openshift-image-registry.svc:5000"
   oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge >&2
+  oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"disableRedirect":true}}' --type=merge >&2
   my_registry=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
   skopeo login -u kubeadmin -p "$(oc whoami -t)" --tls-verify=false "$my_registry" >&2
   oc -n openshift-marketplace delete secret internal-reg-auth-for-rhdh --ignore-not-found >&2


### PR DESCRIPTION
## Description
Updating install-rhdh-catalog-source.sh script by disabling backend redirect to fix authentication issue that was causing the script to fail when run on an ARO cluster.

## Which issue(s) does this PR fix or relate to

- Fixes [RHDHBUGS-2637](https://redhat.atlassian.net/browse/RHDHBUGS-2637)

## PR acceptance criteria

- [x] Tests
- [x] Documentation
