### PR TITLE
backport 1.10 - fix(lightspeed): pre-create /data/vector_db/notebooks in init container

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2026-06-30T19:46:30Z"
+    createdAt: "2026-07-01T20:12:38Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.10
-    createdAt: "2026-06-30T19:46:34Z"
+    createdAt: "2026-07-01T20:12:39Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
@@ -270,7 +270,7 @@ data:
               command:
                 - "sh"
                 - "-c"
-                - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+                - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
               resources:
                 requests:
                   memory: 150Mi

--- a/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
@@ -264,13 +264,15 @@ data:
     spec:
       template:
         spec:
+          securityContext:
+            fsGroup: 1001
           initContainers:
             - name: init-rag-data
               image: quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0
               command:
                 - "sh"
                 - "-c"
-                - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
               resources:
                 requests:
                   memory: 150Mi

--- a/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
@@ -270,7 +270,7 @@ data:
               command:
                 - "sh"
                 - "-c"
-                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model && echo 'Copy complete.'"
+                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model /data/vector_db && echo 'Copy complete.'"
               resources:
                 requests:
                   memory: 150Mi

--- a/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
@@ -264,15 +264,13 @@ data:
     spec:
       template:
         spec:
-          securityContext:
-            fsGroup: 1001
           initContainers:
             - name: init-rag-data
               image: quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0
               command:
                 - "sh"
                 - "-c"
-                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model && echo 'Copy complete.'"
               resources:
                 requests:
                   memory: 150Mi

--- a/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
@@ -9,7 +9,7 @@ spec:
           command:
             - "sh"
             - "-c"
-            - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+            - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
           resources:
             requests:
               memory: 150Mi

--- a/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
@@ -3,15 +3,13 @@ kind: Deployment
 spec:
   template:
     spec:
-      securityContext:
-        fsGroup: 1001
       initContainers:
         - name: init-rag-data
           image: quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0
           command:
             - "sh"
             - "-c"
-            - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+            - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model && echo 'Copy complete.'"
           resources:
             requests:
               memory: 150Mi

--- a/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
@@ -9,7 +9,7 @@ spec:
           command:
             - "sh"
             - "-c"
-            - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model && echo 'Copy complete.'"
+            - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model /data/vector_db && echo 'Copy complete.'"
           resources:
             requests:
               memory: 150Mi

--- a/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
@@ -3,13 +3,15 @@ kind: Deployment
 spec:
   template:
     spec:
+      securityContext:
+        fsGroup: 1001
       initContainers:
         - name: init-rag-data
           image: quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0
           command:
             - "sh"
             - "-c"
-            - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+            - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
           resources:
             requests:
               memory: 150Mi

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -3286,13 +3286,15 @@ data:
     spec:
       template:
         spec:
+          securityContext:
+            fsGroup: 1001
           initContainers:
             - name: init-rag-data
               image: quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0
               command:
                 - "sh"
                 - "-c"
-                - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
               resources:
                 requests:
                   memory: 150Mi

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -3286,15 +3286,13 @@ data:
     spec:
       template:
         spec:
-          securityContext:
-            fsGroup: 1001
           initContainers:
             - name: init-rag-data
               image: quay.io/redhat-ai-dev/rag-content:release-1.10-lls-0.5.0
               command:
                 - "sh"
                 - "-c"
-                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model && echo 'Copy complete.'"
               resources:
                 requests:
                   memory: 150Mi

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -3292,7 +3292,7 @@ data:
               command:
                 - "sh"
                 - "-c"
-                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model && echo 'Copy complete.'"
+                - "echo 'Copying RAG data...'; cp -r --no-preserve=mode,ownership /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R a+rwX /data/embeddings_model /data/vector_db && echo 'Copy complete.'"
               resources:
                 requests:
                   memory: 150Mi

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -3292,7 +3292,7 @@ data:
               command:
                 - "sh"
                 - "-c"
-                - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
+                - "echo 'Copying RAG data...'; cp -r /rag/. /data/ && mkdir -p /data/vector_db/notebooks && chmod -R 777 /data/vector_db && echo 'Copy complete.'"
               resources:
                 requests:
                   memory: 150Mi


### PR DESCRIPTION
On EKS/AKS, the RAG init container copies /rag/. to /data/ but never creates the notebooks subdirectory. At runtime, llama-stack tries to write /rag-content/vector_db/notebooks/faiss_store.db (same volume, mounted at /rag-content in the sidecar) and fails with PermissionError because it cannot create the directory. OCP avoids this via fsGroup defaults; EKS/AKS do not.

The fix pre-creates /data/vector_db/notebooks before the existing chmod so the directory exists and is writable when the sidecar starts.

Fixes: [RHDHBUGS-3371](https://redhat.atlassian.net/browse/RHDHBUGS-3371)

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
