### PR TITLE
ci: simplify `/build-images` to always build PR HEAD

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,13 +25,9 @@ Detailed instructions may help reviewers test this PR quickly and provide quicke
 
 Need to test container images from this PR?
 
-**For Maintainers:** Triggering Builds
-To trigger a test image build, review the code and comment:
-- `/build-images` — builds the HEAD of the PR branch
-- `/build-images <sha>` — builds a specific commit (must be part of the PR)
+**For Maintainers:** To trigger a test image build, review the code and comment `/build-images`.
+This always builds the HEAD of the PR branch.
 
-*(You can find the short SHA at the bottom of the PR timeline or in the Commits tab.)*
-
-**For Contributors:** Ask a maintainer to run `/build-images`
+**For Contributors:** Ask a maintainer to run `/build-images`.
 
 Images will be built and pushed to Quay with links posted in comments.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,11 +26,12 @@ Detailed instructions may help reviewers test this PR quickly and provide quicke
 Need to test container images from this PR?
 
 **For Maintainers:** Triggering Builds
-To trigger a test image build, review the code and comment with the specific commit SHA you are approving:
-`/build-images <sha>` *(e.g., `/build-images a1b2c3d`)*
+To trigger a test image build, review the code and comment:
+- `/build-images` — builds the HEAD of the PR branch
+- `/build-images <sha>` — builds a specific commit (must be part of the PR)
 
-*(You can find the short SHA at the bottom of the PR timeline or in the Commits tab).*
+*(You can find the short SHA at the bottom of the PR timeline or in the Commits tab.)*
 
-**For Contributors:** Ask a maintainer to run `/build-images <sha>`
+**For Contributors:** Ask a maintainer to run `/build-images`
 
 Images will be built and pushed to Quay with links posted in comments.

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -52,30 +52,36 @@ jobs:
             // Extract SHA from the comment, or default to the PR HEAD
             const commentBody = context.payload.comment.body.trim();
             const match = commentBody.match(/^\/build-images\s+([a-f0-9]{7,40})/);
-            const requestedSha = match ? match[1] : pr.data.head.sha;
 
-            // Validate that the SHA belongs to this PR's commits
-            const commits = [];
-            let page = 1;
-            while (true) {
-              const resp = await github.rest.pulls.listCommits({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-                per_page: 100,
-                page,
-              });
-              commits.push(...resp.data.map(c => c.sha));
-              if (resp.data.length < 100) break;
-              page++;
-            }
+            let fullSha;
+            if (!match) {
+              fullSha = pr.data.head.sha;
+            } else {
+              const requestedSha = match[1];
 
-            const fullSha = commits.find(
-              sha => sha === requestedSha || sha.startsWith(requestedSha)
-            );
-            if (!fullSha) {
-              core.setFailed(`❌ Security Gate: SHA ${requestedSha} is not part of PR #${context.issue.number}. Only commits in this PR can be built.`);
-              return;
+              // Validate that the SHA belongs to this PR's commits
+              const commits = [];
+              let page = 1;
+              while (true) {
+                const resp = await github.rest.pulls.listCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                  per_page: 100,
+                  page,
+                });
+                commits.push(...resp.data.map(c => c.sha));
+                if (resp.data.length < 100) break;
+                page++;
+              }
+
+              fullSha = commits.find(
+                sha => sha === requestedSha || sha.startsWith(requestedSha)
+              );
+              if (!fullSha) {
+                core.setFailed(`❌ Security Gate: SHA ${requestedSha} is not part of PR #${context.issue.number}. Only commits in this PR can be built.`);
+                return;
+              }
             }
 
             // Output the frozen, trusted data

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -49,43 +49,7 @@ jobs:
               pull_number: context.issue.number
             });
             
-            // Extract SHA from the comment, or default to the PR HEAD
-            const commentBody = context.payload.comment.body.trim();
-            const match = commentBody.match(/^\/build-images\s+([a-f0-9]{7,40})/);
-
-            let fullSha;
-            if (!match) {
-              fullSha = pr.data.head.sha;
-            } else {
-              const requestedSha = match[1];
-
-              // Validate that the SHA belongs to this PR's commits
-              const commits = [];
-              let page = 1;
-              while (true) {
-                const resp = await github.rest.pulls.listCommits({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: context.issue.number,
-                  per_page: 100,
-                  page,
-                });
-                commits.push(...resp.data.map(c => c.sha));
-                if (resp.data.length < 100) break;
-                page++;
-              }
-
-              fullSha = commits.find(
-                sha => sha === requestedSha || sha.startsWith(requestedSha)
-              );
-              if (!fullSha) {
-                core.setFailed(`❌ Security Gate: SHA ${requestedSha} is not part of PR #${context.issue.number}. Only commits in this PR can be built.`);
-                return;
-              }
-            }
-
-            // Output the frozen, trusted data
-            core.setOutput('sha', fullSha);
+            core.setOutput('sha', pr.data.head.sha);
             core.setOutput('repo', pr.data.head.repo.full_name);
             core.setOutput('number', context.issue.number);
 

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -49,19 +49,37 @@ jobs:
               pull_number: context.issue.number
             });
             
-            // Extract the exact SHA the maintainer authorized from the comment
+            // Extract SHA from the comment, or default to the PR HEAD
             const commentBody = context.payload.comment.body.trim();
             const match = commentBody.match(/^\/build-images\s+([a-f0-9]{7,40})/);
-            
-            if (!match) {
-              core.setFailed("❌ Security Gate: You must provide a specific commit SHA to build. Example: /build-images abc1234");
+            const requestedSha = match ? match[1] : pr.data.head.sha;
+
+            // Validate that the SHA belongs to this PR's commits
+            const commits = [];
+            let page = 1;
+            while (true) {
+              const resp = await github.rest.pulls.listCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+                page,
+              });
+              commits.push(...resp.data.map(c => c.sha));
+              if (resp.data.length < 100) break;
+              page++;
+            }
+
+            const fullSha = commits.find(
+              sha => sha === requestedSha || sha.startsWith(requestedSha)
+            );
+            if (!fullSha) {
+              core.setFailed(`❌ Security Gate: SHA ${requestedSha} is not part of PR #${context.issue.number}. Only commits in this PR can be built.`);
               return;
             }
-            
-            const authorizedSha = match[1];
 
-            // 4. Output the frozen, trusted data
-            core.setOutput('sha', authorizedSha);
+            // Output the frozen, trusted data
+            core.setOutput('sha', fullSha);
             core.setOutput('repo', pr.data.head.repo.full_name);
             core.setOutput('number', context.issue.number);
 


### PR DESCRIPTION
## Description

Follow-up to #2293 (59554ed) — simplifies the `/build-images` slash command to always build the HEAD of the PR branch.

- Removes SHA argument parsing — `/build-images` no longer accepts or requires a commit SHA
- Uses `pr.data.head.sha` directly from the GitHub API, which is trusted and always points to the latest PR commit
- Eliminates the TOCTOU window where a maintainer could (accidentally or intentionally) build from an arbitrary commit in the fork repo

## Which issue(s) does this PR fix or relate to

- Should fix the issue highlighted in https://github.com/redhat-developer/rhdh-operator/pull/3076#issuecomment-4791436087 : commit https://github.com/redhat-developer/rhdh-operator/commit/10e33383b86366329963ff697f81a18153f9b0e4 does not belong to this PR branch, but is on a different branch.

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer

Can only be tested after merging:

- Comment `/build-images` on a PR — should build the PR HEAD
- Verify the built images match the latest commit on the PR branch