### PR TITLE
[release-1.10] ci: simplify `/build-images` to always build PR HEAD

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,12 +25,9 @@ Detailed instructions may help reviewers test this PR quickly and provide quicke
 
 Need to test container images from this PR?
 
-**For Maintainers:** Triggering Builds
-To trigger a test image build, review the code and comment with the specific commit SHA you are approving:
-`/build-images <sha>` *(e.g., `/build-images a1b2c3d`)*
+**For Maintainers:** To trigger a test image build, review the code and comment `/build-images`.
+This always builds the HEAD of the PR branch.
 
-*(You can find the short SHA at the bottom of the PR timeline or in the Commits tab).*
-
-**For Contributors:** Ask a maintainer to run `/build-images <sha>`
+**For Contributors:** Ask a maintainer to run `/build-images`.
 
 Images will be built and pushed to Quay with links posted in comments.

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -49,19 +49,7 @@ jobs:
               pull_number: context.issue.number
             });
 
-            // Extract the exact SHA the maintainer authorized from the comment
-            const commentBody = context.payload.comment.body.trim();
-            const match = commentBody.match(/^\/build-images\s+([a-f0-9]{7,40})/);
-
-            if (!match) {
-              core.setFailed("❌ Security Gate: You must provide a specific commit SHA to build. Example: /build-images abc1234");
-              return;
-            }
-
-            const authorizedSha = match[1];
-
-            // 4. Output the frozen, trusted data
-            core.setOutput('sha', authorizedSha);
+            core.setOutput('sha', pr.data.head.sha);
             core.setOutput('repo', pr.data.head.repo.full_name);
             core.setOutput('number', context.issue.number);
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/redhat-developer/rhdh-operator/pull/3076