### PR TITLE
chore: remove EOL 1.8 from the nightly checks and disable in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,12 @@
   "packageRules": [
     {
       "matchBaseBranches": [
+        "release-1.8"
+      ],
+      "enabled": false
+    },
+    {
+      "matchBaseBranches": [
         "release-1.7"
       ],
       "enabled": false

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,7 +16,6 @@ jobs:
           - main
           - release-1.10
           - release-1.9
-          - release-1.8
     name: 'Nightly Tests on ${{ matrix.branch }}'
     concurrency:
       group: '${{ github.workflow }}-${{ matrix.branch }}'


### PR DESCRIPTION
## Description
1.8 is EOL with the release of 1.10.0. But note that we are still keeping it in the upgrade checks because we should be testing upgrades from an unsupported version as well to make sure it works as expected

## Which issue(s) does this PR fix or relate to

- Fixes https://redhat.atlassian.net/browse/RHIDP-15110

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer

Will check after merging.