### PR TITLE
ci: fix `/build-images` builds cancelled by unrelated PR comments

### DIFF
--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -11,7 +11,11 @@ permissions:
 
 concurrency:
   group: build-images-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  # Must be false: the issue_comment trigger fires on ALL comments (not just /build-images),
+  # but the /build-images filter is only at the job level. With cancel-in-progress: true,
+  # any unrelated comment (e.g. from SonarQube, Renovate) on the same PR would cancel a
+  # running build, then skip the job because the comment doesn't match /build-images.
+  cancel-in-progress: false
 
 env:
   REGISTRY: ${{ vars.REGISTRY }}


### PR DESCRIPTION
## Description

Set `cancel-in-progress: false` in the `/build-images` workflow concurrency group.

The `issue_comment` trigger fires on **all** comments on a PR, but the `/build-images` filter only exists at the job level (`if:` condition). With `cancel-in-progress: true`, any unrelated comment (e.g. from SonarQube, Renovate) on the same PR would cancel a running build, then skip the job because the comment body doesn't match `/build-images`.

Confirmed with PR #3084: `/build-images` was posted at 10:37:47, SonarQube commented at 10:38:36, and the build was cancelled at 10:38:56.

The concurrency group key (`build-images-${{ github.event.issue.number }}`) is already correctly scoped per PR, so different PRs never interfere. With `cancel-in-progress: false`, a bot comment will just queue a no-op run that gets skipped, rather than killing the build.

## Which issue(s) does this PR fix or relate to

- N/A

## PR acceptance criteria

- [x] Tests — CI-only change, no code tests needed
- [x] Documentation — comment in the workflow file explains the rationale

## How to test changes / Special notes to the reviewer

- Comment `/build-images` on a PR, then verify the build is not cancelled when a bot (SonarQube, Renovate) posts a subsequent comment on the same PR
- Comment `/build-images` on multiple unrelated PRs in parallel and verify none get cancelled