### PR TITLE
chore(agent-readiness): bootstrap basic AGENTS.md and minor repo updates for agents

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "api/**/*.go"
+---
+
+# API Types Rules
+
+- New API versions go in `api/v1alphaN/` following the existing version directories.
+- All exported types and fields must have godoc comments (Go convention: comment starts with the symbol name).
+- After modifying any type in `api/`, run `make manifests generate` — the generated CRD YAML and deepcopy code must be committed with the source change.
+- Validation markers (`+kubebuilder:validation:*`) go on struct fields, not separately.
+- Check `api/current-types.go` to understand which API version is current/promoted.

--- a/.claude/rules/controller.md
+++ b/.claude/rules/controller.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "internal/controller/**/*.go"
+---
+
+# Controller Rules
+
+- Reconcile logic lives in `internal/controller/backstage_controller.go`.
+- Use `controllerutil.CreateOrUpdate` for idempotent resource management — avoid plain `Create` which fails on re-reconcile.
+- Gate optional features on CRD presence before registering scheme or adding RBAC.
+- Do not hard-code `replicas` in any Deployment/StatefulSet template — omit to allow HPA.
+- After any controller change, run `make manifests generate fmt vet` before committing.

--- a/.claude/rules/controller.md
+++ b/.claude/rules/controller.md
@@ -6,7 +6,7 @@ paths:
 # Controller Rules
 
 - Reconcile logic lives in `internal/controller/backstage_controller.go`.
-- Use `controllerutil.CreateOrUpdate` for idempotent resource management — avoid plain `Create` which fails on re-reconcile.
+- Use server-side apply (`r.Patch(.., client.Apply, ..)`) for idempotent resource management — avoid plain `Create` which fails on re-reconcile.
 - Gate optional features on CRD presence before registering scheme or adding RBAC.
 - Do not hard-code `replicas` in any Deployment/StatefulSet template — omit to allow HPA.
 - After any controller change, run `make manifests generate fmt vet` before committing.

--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -6,7 +6,7 @@ paths:
 
 # Integration & E2E Test Rules
 
-- Integration tests require a running Kubernetes cluster. Use `make integration-test USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true`.
+- Some integration tests may require a running Kubernetes cluster and/or existing controller. Use `make integration-test USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true`.
 - The `PROFILE` variable selects the test suite: `backstage.io` (faster, default for CI) or `rhdh`.
 - Staticcheck (ST1001) is excluded for test files — dot-imports are allowed.
 - Use `--focus` to run a single test: `make integration-test ARGS='--focus "test name"' USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true`.

--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "integration_tests/**/*.go"
+  - "tests/**/*.go"
+---
+
+# Integration & E2E Test Rules
+
+- Integration tests require a running Kubernetes cluster. Use `make integration-test USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true`.
+- The `PROFILE` variable selects the test suite: `backstage.io` (faster, default for CI) or `rhdh`.
+- Staticcheck (ST1001) is excluded for test files — dot-imports are allowed.
+- Use `--focus` to run a single test: `make integration-test ARGS='--focus "test name"' USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "case \"$CLAUDE_FILE_PATH\" in *.go) gofmt -w \"$CLAUDE_FILE_PATH\" 2>/dev/null || true ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# rhdh-operator
+
+Kubernetes operator for Red Hat Developer Hub (RHDH), based on the Backstage operator.
+Manages `Backstage` CRs and reconciles them into Deployments, ConfigMaps, and related resources.
+
+## Build & Test Commands
+
+- Build: `make build`
+- Test (unit): `make test`
+- Integration test (requires running cluster): `make integration-test PROFILE=backstage.io USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true`
+- Lint: `make lint` (golangci-lint + yamllint)
+- Lint fix: `make lint-fix`
+- Format: `make fmt` (goimports)
+- Security scan: `make gosec`
+- Generate CRD/deepcopy: `make manifests generate`
+- Single-file lint: `golangci-lint run ./path/to/package/...`
+- Single-file vet: `go vet ./path/to/package/...`
+
+## Key Conventions
+
+<!-- TODO (maintainers): Add 2-3 conventions an agent couldn't discover by reading the code.
+     Examples: naming rules, Kubernetes-specific patterns, things that always break if missed.
+     See best_practices.md for patterns already captured from PR reviews. -->
+
+## Architecture
+
+<!-- TODO (maintainers): Document non-obvious architectural decisions or unexpected code locations.
+     Examples: "reconciler logic is split across pkg/ and internal/", "CRD validation happens in the webhook not the controller", invariants that must hold across the reconcile loop. -->
+
+## Pattern References
+
+- CR examples and dependent resources: `examples/`
+- Operator coding patterns (from PR reviews): `best_practices.md`
+- Design and configuration docs: `docs/`
+
+## PR Conventions
+
+- PR description must link the related issue (`Fixes #<issue>`) and include test and documentation checkboxes.
+- Agent-assisted commits should include an `Assisted-by: <model>` footer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Manages `Backstage` CRs and reconciles them into Deployments, ConfigMaps, and re
 ## Build & Test Commands
 
 - Build: `make build`
-- Test (unit): `make test`
-- Integration test (requires running cluster): `make integration-test PROFILE=backstage.io USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true`
+- Test (unit and integration tests not requiring real cluster): `make test`
+- Integration test (on running cluster and controller): `make integration-test PROFILE=backstage.io USE_EXISTING_CLUSTER=true USE_EXISTING_CONTROLLER=true`
 - Lint: `make lint` (golangci-lint + yamllint)
 - Lint fix: `make lint-fix`
 - Format: `make fmt` (goimports)
@@ -23,6 +23,8 @@ Manages `Backstage` CRs and reconciles them into Deployments, ConfigMaps, and re
      See best_practices.md for patterns already captured from PR reviews. -->
 
 ## Architecture
+
+- Design and configuration overview: `docs/design.md`
 
 <!-- TODO (maintainers): Document non-obvious architectural decisions or unexpected code locations.
      Examples: "reconciler logic is split across pkg/ and internal/", "CRD validation happens in the webhook not the controller", invariants that must hold across the reconcile loop. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ gosec: addgosec ## run the gosec scanner for non-test files in this repo
 	$(GOSEC) -no-fail -fmt $(GOSEC_FMT) -out $(GOSEC_OUTPUT_FILE)  ./...
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint vet ## Run golangci-lint linter & yamllint & go vet
 	$(GOLANGCI_LINT) run --timeout 15m
 
 .PHONY: lint-fix


### PR DESCRIPTION
## Description

Ran the agent-ready (https://github.com/redhat-developer/rhdh-skill/blob/main/skills/agent-ready/SKILL.md) skill against the repository, to address some gaps called out by the https://github.com/ambient-code/agentready CLI (to assess an individual repository's readiness to be consumed by agents). 

- Adds an AGENTS.md / CLAUDE.md with basic one-line build and test commands, and a link to some repo docs that could be found
    - **To the maintainers:** I recommend populating the Key conventions and Architecture sections for stuff that isn't immediately obvious to an agent
        - **Do not** auto generate this information, as it can actively harm agent effectiveness
- A couple minor updates to the repo and some claude rules to improve agent consumption

## Which issue(s) does this PR fix or relate to

N/A, but see https://docs.google.com/spreadsheets/d/1Gk3nDQFJ2PBaaPiMZ3naJqAWf-nmL14OwK-Y83k7cuc/edit for more information

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Building Container Images for Testing

Need to test container images from this PR?

**For Maintainers:** To trigger a test image build, review the code and comment `/build-images`.
This always builds the HEAD of the PR branch.

**For Contributors:** Ask a maintainer to run `/build-images`.

Images will be built and pushed to Quay with links posted in comments.
