### PR TITLE
fix: strip `managedFields` from informer cache to prevent potential OOM [RHDHBUGS-3414]

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -204,6 +204,10 @@ func main() {
 		// LeaderElectionReleaseOnCancel: true,
 	}
 
+	// Strip useless managedFields from all cached objects to reduce memory usage.
+	// With many resources, managedFields can consume 70%+ of the informer cache heap.
+	mgrOpts.Cache.DefaultTransform = cache.TransformStripManagedFields()
+
 	// Configure cache to only watch labeled Secrets and ConfigMaps if flag is enabled
 	if enableCacheLabelFilter {
 		setupLog.Info("Enabling cache label filter for Secrets and ConfigMaps")
@@ -217,14 +221,12 @@ func main() {
 			os.Exit(1)
 		}
 
-		mgrOpts.Cache = cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				&corev1.Secret{}: {
-					Label: labelSelector,
-				},
-				&corev1.ConfigMap{}: {
-					Label: labelSelector,
-				},
+		mgrOpts.Cache.ByObject = map[client.Object]cache.ByObject{
+			&corev1.Secret{}: {
+				Label: labelSelector,
+			},
+			&corev1.ConfigMap{}: {
+				Label: labelSelector,
 			},
 		}
 	}


### PR DESCRIPTION
## Description

The RHDH operator OOM-crashes under load because the controller-runtime informer cache holds `PartialObjectMetadata` with bloated `managedFields`. This was observed by the Performance team while testing the Operator as part of the Dev Sandbox integration.

**NOTE**: the Operator was configured with [cache label filtering](https://github.com/redhat-developer/rhdh-operator/blob/main/docs/admin.md#memory-optimization-for-large-clusters) enabled, and all related resources were created with the `rhdh.redhat.com/external-config: "true"` label. So the operator was watching only those labeled resources.

This PR adds [`cache.TransformStripManagedFields()`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache#TransformStripManagedFields) as the `DefaultTransform`, which strips `managedFields` from every object entering the informer cache, and appears to save a lot in memory. The operator does not appear to be using those `managedFields`.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHDHBUGS-3414

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer

See the results from the screenshot below:
- in blue, the current operator (without the changes here): with 2000 namespaces, and in each namespace, a CR + a few linked ConfigMaps and Secrets (labeled with `rhdh.redhat.com/external-config: "true"`) => memory keeps increasing until the operator is OOM-killed
- in green, the operator was updated with the changes here, and we can see that the memory is stabilized with the same number of resources.

<img width="1834" height="837" alt="Screenshot_2026-06-28_19-01-50" src="https://github.com/user-attachments/assets/264507e9-a6fa-4044-ba1d-acc6d20ceea9" />

