### PR TITLE
fix: correct yq install condition and improve robustness

### DIFF
--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -390,13 +390,14 @@ fi
 pushd "${TMPDIR}" >/dev/null
 debugf ">>> WORKING DIR: $TMPDIR <<<"
 
-if [[ $INSTALL_YQ ]]; then
+if (( INSTALL_YQ )); then
   YQ=$HOME/.local/bin/yq_mf
   YQ_BINARY=yq_linux_amd64
+  mkdir -p "$HOME/.local/bin"
   curl -sSLo- https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}.tar.gz | tar xz && mv -f ${YQ_BINARY} "${YQ}"
   debugf "mikefarah yq $YQ_VERSION installed to $YQ"
 else
-  YQ=$(which yq)
+  YQ=$(command -v yq)
 fi
 
 


### PR DESCRIPTION
## Problem

The `INSTALL_YQ` flag in `prepare-restricted-environment.sh` defaults to `0` and is set to `1` when `--install-yq` is passed. However, the condition that checks it uses `[[ $INSTALL_YQ ]]`, which tests whether the string is **non-empty**. Since `"0"` is a non-empty string, the condition is always true — `yq` is always downloaded from GitHub regardless of whether `--install-yq` was passed. The `else` branch (use system `yq`) is dead code.

## Fix

- **Use arithmetic evaluation** `(( INSTALL_YQ ))` instead of `[[ $INSTALL_YQ ]]`. In arithmetic context, `0` evaluates to false and `1` to true, which is the idiomatic Bash pattern for 0/1 boolean flags.
- **Add `mkdir -p "$HOME/.local/bin"`** before moving the downloaded binary, since the directory may not exist in minimal or container environments.
- **Replace `which yq` with `command -v yq`** for POSIX portability and consistency with the script's own `check_tool` function (which already uses `command -v`).