### PR TITLE
chore: only sync release branches for lightspeed

### DIFF
--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - main
           - release-1.10
 
     concurrency:


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

Updates the sync scheduled job to only sync the release branches with changes. For 2.1.0 we will be making significant changes to the lightspeed configs and the resulting sync PRs will be confusing and breaking. We will manually keep them updated during the development process where necessary.

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Building Container Images for Testing

Need to test container images from this PR?

**For Maintainers:** To trigger a test image build, review the code and comment `/build-images`.
This always builds the HEAD of the PR branch.

**For Contributors:** Ask a maintainer to run `/build-images`.

Images will be built and pushed to Quay with links posted in comments.
