### PR TITLE
generate default dynamic plugins and app-config plugins ConfigMaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ PROFILES := $(shell find config/manifests -mindepth 1 -maxdepth 1 -type d -exec 
 # to use other config - add a directory with config,
 # use it as following commands: 'PROFILE=<dir-name> make test|integration-test|run|deploy|deployment-manifest'
 PROFILE ?= rhdh
+
+# Enable operator dynamic plugins processing (default: true)
+OPERATOR_DP_PROCESSING ?= true
 PROFILE_SHORT := $(shell echo $(PROFILE) | cut -d. -f1)
 
 # VERSION defines the project version for the bundle.
@@ -167,7 +170,7 @@ fmt: goimports ## Format the code using goimports
 .PHONY: test
 test: manifests generate fmt vet setup-envtest $(LOCALBIN) ## Run tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
 	@./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
-	OPERATOR_DP_PROCESSING=true LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(PKGS) -coverprofile cover.out
+	OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(PKGS) -coverprofile cover.out
 
 .PHONY: integration-test
 integration-test: ginkgo manifests generate fmt vet envtest $(LOCALBIN) ## Run integration_tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
@@ -232,7 +235,7 @@ build: manifests generate fmt vet ## Build manager binary.
 .PHONY: run
 run: manifests generate fmt vet $(LOCALBIN) ## Run a controller from your host.
 	@./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
-	OPERATOR_DP_PROCESSING=true go run -C $(LOCALBIN) ../cmd/main.go $(ARGS)
+	OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) go run -C $(LOCALBIN) ../cmd/main.go $(ARGS)
 
 # TODO @IMAGE=$(CATALOG_INDEX_IMAGE) ./hack/create-local-dynamic-plugins.sh - when catalog become stable
 .PHONY: local-dynamic-plugins

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ test: manifests generate fmt vet setup-envtest $(LOCALBIN) ## Run tests. We need
 .PHONY: integration-test
 integration-test: ginkgo manifests generate fmt vet envtest $(LOCALBIN) ## Run integration_tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
 	@./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
-	LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -v -r $(ARGS) integration_tests
+	OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -v -r $(ARGS) integration_tests
 
 # After this time, Ginkgo will emit progress reports, so we can get visibility into long-running tests.
 POLL_PROGRESS_INTERVAL := 600s

--- a/Makefile
+++ b/Makefile
@@ -169,12 +169,12 @@ fmt: goimports ## Format the code using goimports
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest $(LOCALBIN) ## Run tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
-	@./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
+	@OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) ./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
 	OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(PKGS) -coverprofile cover.out
 
 .PHONY: integration-test
 integration-test: ginkgo manifests generate fmt vet envtest $(LOCALBIN) ## Run integration_tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
-	@./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
+	@OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) ./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
 	OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -v -r $(ARGS) integration_tests
 
 # After this time, Ginkgo will emit progress reports, so we can get visibility into long-running tests.
@@ -234,7 +234,7 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet $(LOCALBIN) ## Run a controller from your host.
-	@./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
+	@OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) ./hack/copy-local-dynamic-plugins.sh $(PROFILE) $(LOCALBIN)
 	OPERATOR_DP_PROCESSING=$(OPERATOR_DP_PROCESSING) go run -C $(LOCALBIN) ../cmd/main.go $(ARGS)
 
 # TODO @IMAGE=$(CATALOG_INDEX_IMAGE) ./hack/create-local-dynamic-plugins.sh - when catalog become stable

--- a/hack/copy-local-dynamic-plugins.sh
+++ b/hack/copy-local-dynamic-plugins.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# Copy default-config and plugin-deps to LOCALBIN for 'make run'
+# Copy default-config and plugin-deps to LOCALBIN for 'make run' and 'make test'
 #
-# For all profiles: copies default-config and plugin-deps
-# For 'rhdh' profile only: overlays dynamic-plugins.yaml from local-test
+# Dynamic plugins source depends on OPERATOR_DP_PROCESSING:
+#   - true:  uses local-test/dynamic-plugins.yaml (rhdh profile only)
+#   - false: uses default-config/dynamic-plugins.yaml
 #
 # Usage: ./hack/copy-local-dynamic-plugins.sh <PROFILE> <LOCALBIN>
 
@@ -16,8 +17,7 @@ PLUGIN_DEPS_SRC="config/profile/${PROFILE}/plugin-deps"
 DEFAULT_CONFIG_TARGET="${LOCALBIN}/default-config"
 PLUGIN_DEPS_TARGET="${LOCALBIN}/plugin-deps"
 
-# Step 1: Copy default-config for all profiles
-# This includes dynamic-plugins.yaml from default-config
+# Step 1: Copy default-config
 mkdir -p "${DEFAULT_CONFIG_TARGET}"
 rm -fr "${DEFAULT_CONFIG_TARGET:?}"/*
 cp -r "${DEFAULT_CONFIG_SRC}"/* "${DEFAULT_CONFIG_TARGET}/"
@@ -29,9 +29,8 @@ if [[ -d "${PLUGIN_DEPS_SRC}" ]]; then
     cp -r "${PLUGIN_DEPS_SRC}"/* "${PLUGIN_DEPS_TARGET}/" 2>/dev/null || :
 fi
 
-# Step 3: For rhdh profile only, overlay dynamic-plugins.yaml from local-test
-# (replaces the one copied from default-config)
-if [[ "${PROFILE}" == "rhdh" ]]; then
+# Step 3: For OPERATOR_DP_PROCESSING=true and rhdh profile, overlay dynamic-plugins.yaml from local-test
+if [[ "${OPERATOR_DP_PROCESSING:-false}" == "true" && "${PROFILE}" == "rhdh" ]]; then
     LOCAL_TEST_DIR="config/profile/${PROFILE}/local-test"
     DYNAMIC_PLUGINS_FILE="${LOCAL_TEST_DIR}/dynamic-plugins.yaml"
 
@@ -53,4 +52,7 @@ if [[ "${PROFILE}" == "rhdh" ]]; then
     fi
 
     cp "${DYNAMIC_PLUGINS_FILE}" "${DEFAULT_CONFIG_TARGET}/"
+    echo "Using local-test dynamic-plugins.yaml (OPERATOR_DP_PROCESSING=true)"
+else
+    echo "Using default-config dynamic-plugins.yaml (OPERATOR_DP_PROCESSING=${OPERATOR_DP_PROCESSING:-false})"
 fi

--- a/integration_tests/config-refresh_test.go
+++ b/integration_tests/config-refresh_test.go
@@ -285,5 +285,5 @@ organization:
 		// NOTE: it does not work well on envtest, real controller needed
 		g.Expect(fmt.Sprintf("%s%s", newEnv, "\r\n")).To(Equal(out2))
 
-	}, 10*time.Minute, 10*time.Second).Should(Succeed(), controllerMessage())
+	}, 5*time.Minute, 10*time.Second).Should(Succeed(), controllerMessage())
 }

--- a/integration_tests/rhdh-config_test.go
+++ b/integration_tests/rhdh-config_test.go
@@ -120,8 +120,6 @@ var _ = When("create default rhdh", func() {
 				g.Expect(initCont.Env[0].Value).To(Equal("/opt/app-root/src/.npmrc.dynamic-plugins/.npmrc"))
 			}
 
-			///////////////////////////////////////////
-
 			// no default lightspeed
 			//g.Expect(deploy.PodSpec().Volumes).To(HaveLen(8))
 			//g.Expect(deploy.PodSpec().Containers).To(HaveLen(1))

--- a/integration_tests/rhdh-config_test.go
+++ b/integration_tests/rhdh-config_test.go
@@ -58,8 +58,6 @@ var _ = When("create default rhdh", func() {
 			// with lightspeed
 			//g.Expect(deploy.PodSpec().InitContainers).To(HaveLen(2))
 
-			///////////////////// DP
-
 			if !model.IsOperatorDPProcessing() {
 
 				_, initCont := model.DynamicPluginsInitContainer(deploy.PodSpec().InitContainers)

--- a/integration_tests/rhdh-config_test.go
+++ b/integration_tests/rhdh-config_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/redhat-developer/rhdh-operator/pkg/utils"
-
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/redhat-developer/rhdh-operator/pkg/model"
@@ -59,62 +58,69 @@ var _ = When("create default rhdh", func() {
 			// with lightspeed
 			//g.Expect(deploy.PodSpec().InitContainers).To(HaveLen(2))
 
-			_, initCont := model.DynamicPluginsInitContainer(deploy.PodSpec().InitContainers)
+			///////////////////// DP
 
-			initContainerExpectedVolumeMounts := []corev1.VolumeMount{
-				{
-					Name:      "dynamic-plugins-root",
-					MountPath: "/dynamic-plugins-root",
-					SubPath:   "",
-				},
-				{
-					Name:      model.DefaultMultiObjectName("files", backstageName, "dynamic-plugins-npmrc"),
-					MountPath: "/opt/app-root/src/.npmrc.dynamic-plugins",
-					SubPath:   "",
-				},
-				// TODO - configure this when have defined dynamic plugins OCI registry
-				{
-					Name:      "dynamic-plugins-registry-auth",
-					MountPath: "/opt/app-root/src/.config/containers",
-					SubPath:   "",
-				},
-				{
-					Name:      "npmcacache",
-					MountPath: "/opt/app-root/src/.npm/_cacache",
-					SubPath:   "",
-				},
-				{
-					Name:      utils.GenerateVolumeNameFromCmOrSecret(model.DynamicPluginsDefaultName(backstageName)),
-					MountPath: "/opt/app-root/src/dynamic-plugins.yaml",
-					SubPath:   "dynamic-plugins.yaml",
-				},
-				{
-					Name:      "extensions-catalog",
-					MountPath: "/extensions",
-				},
-				{
-					Name:      "temp",
-					MountPath: "/tmp",
-					SubPath:   "",
-				},
-			}
+			if !model.IsOperatorDPProcessing() {
 
-			g.Expect(initCont.VolumeMounts).To(HaveLen(len(initContainerExpectedVolumeMounts)))
+				_, initCont := model.DynamicPluginsInitContainer(deploy.PodSpec().InitContainers)
 
-			for _, evm := range initContainerExpectedVolumeMounts {
-				found := false
-				for _, vm := range initCont.VolumeMounts {
-					if vm.Name == evm.Name {
-						found = true
-						g.Expect(vm.MountPath).To(Equal(evm.MountPath))
-						g.Expect(vm.SubPath).To(Equal(evm.SubPath))
-					}
+				initContainerExpectedVolumeMounts := []corev1.VolumeMount{
+					{
+						Name:      "dynamic-plugins-root",
+						MountPath: "/dynamic-plugins-root",
+						SubPath:   "",
+					},
+					{
+						Name:      model.DefaultMultiObjectName("files", backstageName, "dynamic-plugins-npmrc"),
+						MountPath: "/opt/app-root/src/.npmrc.dynamic-plugins",
+						SubPath:   "",
+					},
+					// TODO - configure this when have defined dynamic plugins OCI registry
+					{
+						Name:      "dynamic-plugins-registry-auth",
+						MountPath: "/opt/app-root/src/.config/containers",
+						SubPath:   "",
+					},
+					{
+						Name:      "npmcacache",
+						MountPath: "/opt/app-root/src/.npm/_cacache",
+						SubPath:   "",
+					},
+					{
+						Name:      utils.GenerateVolumeNameFromCmOrSecret(model.DynamicPluginsDefaultName(backstageName)),
+						MountPath: "/opt/app-root/src/dynamic-plugins.yaml",
+						SubPath:   "dynamic-plugins.yaml",
+					},
+					{
+						Name:      "extensions-catalog",
+						MountPath: "/extensions",
+					},
+					{
+						Name:      "temp",
+						MountPath: "/tmp",
+						SubPath:   "",
+					},
 				}
-				g.Expect(found).To(BeTrue())
+
+				g.Expect(initCont.VolumeMounts).To(HaveLen(len(initContainerExpectedVolumeMounts)))
+
+				for _, evm := range initContainerExpectedVolumeMounts {
+					found := false
+					for _, vm := range initCont.VolumeMounts {
+						if vm.Name == evm.Name {
+							found = true
+							g.Expect(vm.MountPath).To(Equal(evm.MountPath))
+							g.Expect(vm.SubPath).To(Equal(evm.SubPath))
+						}
+					}
+					g.Expect(found).To(BeTrue())
+				}
+
+				g.Expect(initCont.Env[0].Name).To(Equal("NPM_CONFIG_USERCONFIG"))
+				g.Expect(initCont.Env[0].Value).To(Equal("/opt/app-root/src/.npmrc.dynamic-plugins/.npmrc"))
 			}
 
-			g.Expect(initCont.Env[0].Name).To(Equal("NPM_CONFIG_USERCONFIG"))
-			g.Expect(initCont.Env[0].Value).To(Equal("/opt/app-root/src/.npmrc.dynamic-plugins/.npmrc"))
+			///////////////////////////////////////////
 
 			// no default lightspeed
 			//g.Expect(deploy.PodSpec().Volumes).To(HaveLen(8))
@@ -124,13 +130,6 @@ var _ = When("create default rhdh", func() {
 			// TODO restore it
 			//g.Expect(deploy.PodSpec().Volumes).To(HaveLen(13))
 			//g.Expect(deploy.PodSpec().Containers).To(HaveLen(7))
-
-			mainCont := backstageContainer(*deploy.PodSpec())
-			g.Expect(mainCont.Args).To(HaveLen(4))
-			g.Expect(mainCont.Args[0]).To(Equal("--config"))
-			g.Expect(mainCont.Args[1]).To(Equal("dynamic-plugins-root/app-config.dynamic-plugins.yaml"))
-			g.Expect(mainCont.Args[2]).To(Equal("--config"))
-			g.Expect(mainCont.Args[3]).To(Equal("/opt/app-root/src/default.app-config.yaml"))
 
 			mainContainerExpectedVolumeMounts := []corev1.VolumeMount{
 				{
@@ -150,6 +149,26 @@ var _ = When("create default rhdh", func() {
 					Name:      "temp",
 					MountPath: "/tmp",
 				},
+			}
+
+			mainCont := backstageContainer(*deploy.PodSpec())
+			g.Expect(mainCont.Args[0]).To(Equal("--config"))
+			// additional from deployment manifest exists but not working if OperatorDPProcessing
+			g.Expect(mainCont.Args[1]).To(Equal("dynamic-plugins-root/app-config.dynamic-plugins.yaml"))
+
+			if model.IsOperatorDPProcessing() {
+				// additional from deployment manifest is not used
+				g.Expect(mainCont.Args).To(HaveLen(6))
+				g.Expect(mainCont.Args[3]).To(Equal("/opt/app-root/src/app-config.plugins.yaml"))
+				g.Expect(mainCont.Args[5]).To(Equal("/opt/app-root/src/default.app-config.yaml"))
+				mainContainerExpectedVolumeMounts = append(mainContainerExpectedVolumeMounts, corev1.VolumeMount{
+					Name:      model.DefaultMultiObjectName("appconfig", backstageName, "plugins-appconfig"),
+					MountPath: "/opt/app-root/src/app-config.plugins.yaml",
+					SubPath:   "app-config.plugins.yaml",
+				})
+			} else {
+				g.Expect(mainCont.Args).To(HaveLen(4))
+				g.Expect(mainCont.Args[3]).To(Equal("/opt/app-root/src/default.app-config.yaml"))
 			}
 
 			g.Expect(mainCont.VolumeMounts).To(HaveLen(len(mainContainerExpectedVolumeMounts)))

--- a/pkg/model/appconfig.go
+++ b/pkg/model/appconfig.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"gopkg.in/yaml.v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -12,6 +15,8 @@ import (
 	"github.com/redhat-developer/rhdh-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 )
+
+const PluginsAppConfigFile = "app-config.plugins.yaml"
 
 type AppConfigFactory struct{}
 
@@ -55,8 +60,48 @@ func (b *AppConfig) addToModel(model *BackstageModel, backstage api.Backstage, c
 
 	// Always add to model so updateAndValidate is called (may process spec ConfigMaps)
 	model.setRuntimeObject(b)
-	b.setMetaInfo(backstage, scheme)
 
+	return nil
+}
+
+// addPluginsAppConfig creates a ConfigMap with merged pluginConfig from all enabled plugins
+// and prepends it to b.ConfigMaps.Items. Does nothing if there are no plugin configs.
+func (b *AppConfig) addPluginsAppConfig(namespace string) error {
+	dpObj := b.model.GetRuntimeObject(DynamicPluginsKey)
+	if dpObj == nil {
+		return nil
+	}
+
+	plugins := dpObj.(*DynamicPlugins).enabledPlugins
+	if plugins == nil {
+		return nil
+	}
+
+	mergedConfig := make(map[string]interface{})
+	for _, plugin := range plugins {
+		mergePluginConfigs(mergedConfig, plugin.PluginConfig)
+	}
+	if len(mergedConfig) == 0 {
+		return nil
+	}
+
+	configYaml, err := yaml.Marshal(mergedConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal plugin configs: %w", err)
+	}
+
+	pluginsCM := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plugins-appconfig",
+			Namespace: namespace,
+		},
+		Data: map[string]string{PluginsAppConfigFile: string(configYaml)},
+	}
+	b.ConfigMaps.Items = append([]client.Object{pluginsCM}, b.ConfigMaps.Items...)
 	return nil
 }
 
@@ -68,6 +113,11 @@ func (b *AppConfig) updateAndValidate(backstage api.Backstage, scheme *runtime.S
 	}
 
 	// Get plugins app-config CM if any and add to b.ConfigMaps on the first place
+	if err := b.addPluginsAppConfig(backstage.Namespace); err != nil {
+		return err
+	}
+
+	b.setMetaInfo(backstage, scheme)
 
 	// Process ConfigMaps from config files
 	if b.ConfigMaps != nil {
@@ -120,6 +170,43 @@ func updatePodWithAppConfig(bsd *BackstageDeployment, cmName, mountPath, key str
 		if key == "" || key == file {
 			container.Args = append(container.Args, []string{"--config", filepath.Join(mountPath, file)}...)
 		}
+	}
+	return nil
+}
+
+// mergePluginConfigs recursively merges src plugin config into dst. Maps are merged deeply, other values are overwritten.
+func mergePluginConfigs(dst, src map[string]interface{}) {
+	for k, srcVal := range src {
+		srcMap := toStringKeyedMap(srcVal)
+		if dstVal, exists := dst[k]; exists {
+			dstMap := toStringKeyedMap(dstVal)
+			if srcMap != nil && dstMap != nil {
+				mergePluginConfigs(dstMap, srcMap)
+				dst[k] = dstMap
+				continue
+			}
+		}
+		// Assign new value, converting maps to string-keyed
+		if srcMap != nil {
+			dst[k] = srcMap
+		} else {
+			dst[k] = srcVal
+		}
+	}
+}
+
+// toStringKeyedMap converts map[interface{}]interface{} (from yaml.v2) to map[string]interface{}.
+// Returns the map as-is if already string-keyed, or nil if not a map.
+func toStringKeyedMap(v interface{}) map[string]interface{} {
+	switch m := v.(type) {
+	case map[string]interface{}:
+		return m
+	case map[interface{}]interface{}:
+		result := make(map[string]interface{})
+		for key, val := range m {
+			result[key.(string)] = val
+		}
+		return result
 	}
 	return nil
 }

--- a/pkg/model/appconfig_test.go
+++ b/pkg/model/appconfig_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/redhat-developer/rhdh-operator/pkg/model/multiobject"
 	"github.com/redhat-developer/rhdh-operator/pkg/platform"
 	"github.com/redhat-developer/rhdh-operator/pkg/utils"
 	"golang.org/x/exp/maps"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/redhat-developer/rhdh-operator/api"
 
@@ -170,4 +172,71 @@ func TestMultiEntryAppConfigNotAllowed(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "multiple entries")
 	assert.Contains(t, err.Error(), multiEntryCmName)
+}
+
+func TestAddPluginsAppConfig(t *testing.T) {
+	t.Setenv(OperatorDPProcessingEnvVar, "true")
+
+	t.Run("no pluginConfig - no ConfigMap", func(t *testing.T) {
+		model := &BackstageModel{RuntimeObjects: []RuntimeObject{}}
+		dp := &DynamicPlugins{
+			enabledPlugins:   []DynaPlugin{{Package: "plugin-a"}},
+			enabledPluginsCM: &corev1.ConfigMap{},
+		}
+		model.RuntimeObjects = append(model.RuntimeObjects, dp)
+
+		appConfig := &AppConfig{
+			model:      model,
+			ConfigMaps: &multiobject.MultiObject{Items: []client.Object{}},
+		}
+
+		err := appConfig.addPluginsAppConfig("test-ns")
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(appConfig.ConfigMaps.Items))
+	})
+
+	t.Run("with pluginConfig - deep merged with yaml types", func(t *testing.T) {
+		// Simulate yaml.v2 unmarshaling which produces map[interface{}]interface{}
+		model := &BackstageModel{RuntimeObjects: []RuntimeObject{}}
+		dp := &DynamicPlugins{
+			enabledPlugins: []DynaPlugin{
+				{
+					Package: "plugin-a",
+					PluginConfig: map[string]interface{}{
+						"dynamicPlugins": map[interface{}]interface{}{
+							"frontend": map[interface{}]interface{}{
+								"plugin-a": "config-a",
+							},
+						},
+					},
+				},
+				{
+					Package: "plugin-b",
+					PluginConfig: map[string]interface{}{
+						"dynamicPlugins": map[interface{}]interface{}{
+							"frontend": map[interface{}]interface{}{
+								"plugin-b": "config-b",
+							},
+						},
+					},
+				},
+			},
+			enabledPluginsCM: &corev1.ConfigMap{},
+		}
+		model.RuntimeObjects = append(model.RuntimeObjects, dp)
+
+		appConfig := &AppConfig{
+			model:      model,
+			ConfigMaps: &multiobject.MultiObject{Items: []client.Object{}},
+		}
+
+		err := appConfig.addPluginsAppConfig("test-ns")
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(appConfig.ConfigMaps.Items))
+
+		cm := appConfig.ConfigMaps.Items[0].(*corev1.ConfigMap)
+		// Both plugins should be present (deep merged, not overwritten)
+		assert.Contains(t, cm.Data[PluginsAppConfigFile], "plugin-a")
+		assert.Contains(t, cm.Data[PluginsAppConfigFile], "plugin-b")
+	})
 }

--- a/pkg/model/dynamic-plugins-reference_test.go
+++ b/pkg/model/dynamic-plugins-reference_test.go
@@ -201,6 +201,8 @@ func TestResolveReferences(t *testing.T) {
 }
 
 func TestMergePluginsDataWithInherit(t *testing.T) {
+	t.Setenv(OperatorDPProcessingEnvVar, "true")
+
 	// Default config with versioned plugins
 	defaultData := `
 plugins:
@@ -232,6 +234,8 @@ plugins:
 }
 
 func TestMergePluginsDataWithInheritError(t *testing.T) {
+	t.Setenv(OperatorDPProcessingEnvVar, "true")
+
 	defaultData := `
 plugins:
   - package: "oci://quay.io/rhdh/plugin-a@sha256:abc123"

--- a/pkg/model/dynamic-plugins.go
+++ b/pkg/model/dynamic-plugins.go
@@ -3,9 +3,10 @@ package model
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v2"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/redhat-developer/rhdh-operator/api"
@@ -36,12 +37,10 @@ func (f DynamicPluginsFactory) newBackstageObject() RuntimeObject {
 }
 
 type DynamicPlugins struct {
-	ConfigMap *corev1.ConfigMap
-	model     *BackstageModel
-	//EffectivePlugins      *corev1.ConfigMap
-	//EffectiveAppConfig    *corev1.ConfigMap
-	//EffectiveDependencies []PluginDependency
-	//dynaPlugins           []DynaPlugin
+	ConfigMap        *corev1.ConfigMap
+	model            *BackstageModel
+	enabledPlugins   []DynaPlugin
+	enabledPluginsCM *corev1.ConfigMap
 }
 
 type DynaPluginsConfig struct {
@@ -58,16 +57,6 @@ type DynaPlugin struct {
 	Disabled     bool                   `yaml:"disabled"`
 	PluginConfig map[string]interface{} `yaml:"pluginConfig,omitempty"`
 	Dependencies []PluginDependency     `yaml:"dependencies,omitempty"`
-}
-
-// IsDisabled resolves the effective disabled state from the Enabled and
-// Disabled fields. Enabled takes precedence when both are set. When neither
-// is set the plugin is considered enabled (not disabled), preserving previous behaviour.
-func (p DynaPlugin) IsDisabled() bool {
-	if p.Enabled != nil {
-		return !*p.Enabled
-	}
-	return p.Disabled
 }
 
 type PluginDependency struct {
@@ -87,6 +76,14 @@ func IsOperatorDPProcessing() bool {
 }
 
 func (p *DynamicPlugins) Object() runtime.Object {
+
+	if IsOperatorDPProcessing() {
+		if p.enabledPluginsCM == nil {
+			return nil
+		}
+		return p.enabledPluginsCM
+	}
+
 	if p.ConfigMap == nil {
 		return nil
 	}
@@ -116,17 +113,6 @@ func (p *DynamicPlugins) addToModel(model *BackstageModel, backstage api.Backsta
 			return fmt.Errorf("dynamic plugin configMap expects '%s' Data key", DynamicPluginsFile)
 		}
 
-		//// resolve references
-		// TODO
-		//plugins, err := GetPluginsData(specPlugins)
-		//if err != nil {
-		//	return err
-		//}
-		//for _, plugin := range plugins {
-		//	if plugin.Package
-		//
-		//}
-
 		if p.ConfigMap != nil {
 			// Merge user's config with default config
 			//mergedData, err := p.mergeWith(specPlugins.Data[DynamicPluginsFile])
@@ -146,6 +132,37 @@ func (p *DynamicPlugins) addToModel(model *BackstageModel, backstage api.Backsta
 		}
 	}
 
+	if IsOperatorDPProcessing() && p.ConfigMap != nil {
+
+		p.enabledPlugins = make([]DynaPlugin, 0)
+		pluginsData, err := GetPluginsData(p.ConfigMap)
+		if err != nil {
+			return err
+		}
+
+		packages := []string{}
+		for _, plugin := range pluginsData {
+			if !plugin.IsDisabled() {
+				p.enabledPlugins = append(p.enabledPlugins, plugin)
+				packages = append(packages, plugin.Package)
+			}
+		}
+
+		p.enabledPluginsCM = &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      DynamicPluginsDefaultName(backstage.Name),
+				Namespace: backstage.Namespace,
+			},
+			Data: map[string]string{"packages.txt": strings.Join(packages, "\n")},
+		}
+		setMetaInfo(p.enabledPluginsCM, backstage, scheme)
+
+	}
+
 	p.setMetaInfo(backstage, scheme)
 	// Always add wrapper to model (unconditional)
 	model.setRuntimeObject(p)
@@ -154,10 +171,7 @@ func (p *DynamicPlugins) addToModel(model *BackstageModel, backstage api.Backsta
 }
 
 // ConfigMap name must be the same as (deployment.yaml).spec.template.spec.volumes.name.dynamic-plugins-conf.ConfigMap.name
-// TODO
-// extract pluginConfigs
-// merge with app-config (deep merge)
-func (p *DynamicPlugins) updateAndValidate(backstage api.Backstage, _ *runtime.Scheme) error {
+func (p *DynamicPlugins) updateAndValidate(backstage api.Backstage, scheme *runtime.Scheme) error {
 
 	// Only proceed if there's a ConfigMap to mount or dynamic plugins config in spec
 	if p.ConfigMap == nil && (backstage.Spec.Application == nil || backstage.Spec.Application.DynamicPluginsConfigMapName == "") {
@@ -175,6 +189,15 @@ func (p *DynamicPlugins) updateAndValidate(backstage api.Backstage, _ *runtime.S
 		return fmt.Errorf("failed to find initContainer named %s", dynamicPluginInitContainerName)
 	}
 
+	if p.enabledPluginsCM != nil {
+
+		if err := deployment.mountFilesFrom(containersFilter{names: []string{dynamicPluginInitContainerName}}, ConfigMapObjectKind,
+			p.enabledPluginsCM.Name, initContainer.WorkingDir, "packages.txt", true, utils.SortedKeys(p.enabledPluginsCM.Data)); err != nil {
+			return fmt.Errorf("failed to mount dynamic plugins configMap: %w", err)
+		}
+		return nil
+	}
+
 	if err := deployment.mountFilesFrom(containersFilter{names: []string{dynamicPluginInitContainerName}}, ConfigMapObjectKind,
 		p.ConfigMap.Name, initContainer.WorkingDir, DynamicPluginsFile, true, utils.SortedKeys(p.ConfigMap.Data)); err != nil {
 		return fmt.Errorf("failed to mount dynamic plugins configMap: %w", err)
@@ -188,6 +211,16 @@ func (p *DynamicPlugins) setMetaInfo(backstage api.Backstage, scheme *runtime.Sc
 		p.ConfigMap.SetName(DynamicPluginsDefaultName(backstage.Name))
 		setMetaInfo(p.ConfigMap, backstage, scheme)
 	}
+}
+
+// IsDisabled resolves the effective disabled state from the Enabled and
+// Disabled fields. Enabled takes precedence when both are set. When neither
+// is set the plugin is considered enabled (not disabled), preserving previous behaviour.
+func (p DynaPlugin) IsDisabled() bool {
+	if p.Enabled != nil {
+		return !*p.Enabled
+	}
+	return p.Disabled
 }
 
 // Dependencies returns a list of plugin dependencies


### PR DESCRIPTION
## Description
If OPERATOR_DP_PROCESSING=true (default for make test and make run):
- generate ConfigMap with enabled plugins list
- generate app-config for enabled plugins

## Which issue(s) does this PR fix or relate to



## PR acceptance criteria

- [x] Tests
- [ ] Documentation (intentionally, later)

## How to test changes / Special notes to the reviewer
Run locally 'make install run' and create Backstage CR, look at backstage-appconfig-{cr-name}-plugins-appconfig and backstage-dynamic-plugins-{cr-name} ConfigMaps

## Building Container Images for Testing

Need to test container images from this PR?

**For Maintainers:** To trigger a test image build, review the code and comment `/build-images`.
This always builds the HEAD of the PR branch.

**For Contributors:** Ask a maintainer to run `/build-images`.

Images will be built and pushed to Quay with links posted in comments.
