### PR TITLE
fix: add skopeo retry logic to process_bundle for registry resilience

### DIFF
--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -170,9 +170,21 @@ function process_bundle() {
   local bundle_dir="bundles/${digest}"
   mkdir -p "${bundle_dir}"
 
-  # Failed copies are faster than successful inspects.
-  if ! skopeo copy "docker://$bundleImg" "oci:./${bundle_dir}/src:latest" 2>"${bundle_dir}/copy.err"; then
-    debugf "bundle #${bundle_id}: skopeo copy failed, skipping (see ${bundle_dir}/copy.err)" >&2
+  local max_retries="${SKOPEO_RETRIES:-3}"
+  local retry_delay="${SKOPEO_RETRY_DELAY:-5}"
+
+  local pull_attempt
+  local pull_ok=false
+  for pull_attempt in $(seq 1 "$max_retries"); do
+    if skopeo copy "docker://$bundleImg" "oci:./${bundle_dir}/src:latest" 2>"${bundle_dir}/copy.err"; then
+      pull_ok=true
+      break
+    fi
+    debugf "bundle #${bundle_id}: pull attempt ${pull_attempt}/${max_retries} failed, retrying in ${retry_delay}s..." >&2
+    sleep "$retry_delay"
+  done
+  if [[ "$pull_ok" != "true" ]]; then
+    debugf "bundle #${bundle_id}: skopeo copy failed after ${max_retries} attempts, skipping (see ${bundle_dir}/copy.err)" >&2
     return 0
   fi
   debugf "bundle #${bundle_id}: pulled ${bundleImg}" >&2
@@ -192,7 +204,20 @@ function process_bundle() {
   umoci repack --image "./${bundle_dir}/src:latest" "./${bundle_dir}/unpacked"
 
   local newBundleImage="${my_registry}/rhdh/rhdh-operator-bundle:${digest}"
-  skopeo copy --dest-tls-verify=false "oci:./${bundle_dir}/src:latest" "docker://${newBundleImage}"
+  local push_attempt
+  local push_ok=false
+  for push_attempt in $(seq 1 "$max_retries"); do
+    if skopeo copy --dest-tls-verify=false "oci:./${bundle_dir}/src:latest" "docker://${newBundleImage}" 2>"${bundle_dir}/push.err"; then
+      push_ok=true
+      break
+    fi
+    debugf "bundle #${bundle_id}: push attempt ${push_attempt}/${max_retries} failed, retrying in ${retry_delay}s..." >&2
+    sleep "$retry_delay"
+  done
+  if [[ "$push_ok" != "true" ]]; then
+    errorf "bundle #${bundle_id}: push to registry failed after ${max_retries} attempts (see ${bundle_dir}/push.err)" >&2
+    return 1
+  fi
   debugf "bundle #${bundle_id}: pushed to ${newBundleImage}" >&2
 
   local newBundleImageAsInt="${internal_registry_url}/rhdh/rhdh-operator-bundle:${digest}"


### PR DESCRIPTION
## Summary

OSD-GCP clusters' internal OpenShift image registries intermittently drop connections (EOF errors) under parallel `skopeo copy` load during operator bundle pushes in `install-rhdh-catalog-source.sh`. This causes the `process_bundle()` function to fail, which cascades into a complete operator installation failure.

This PR adds configurable retry logic to both the **pull** and **push** `skopeo copy` operations inside `process_bundle()`:

- **Pull retry**: 3 attempts with 5s backoff when copying from the source registry to local OCI (previously failed silently with `return 0`)
- **Push retry**: 3 attempts with 5s backoff when copying from local OCI to the cluster's internal registry (previously had no retry and failed fatally)
- Retry parameters are configurable via `SKOPEO_RETRIES` (default: 3) and `SKOPEO_RETRY_DELAY` (default: 5s) environment variables

## Root Cause

During RHDH e2e CI nightly runs on OSD-GCP, the internal OpenShift image registry route (`default-route-openshift-image-registry.apps.*.openshiftapps.com`) drops connections under concurrent load. With `MAX_PARALLEL=10` (default), multiple bundles push simultaneously, and the registry responds with EOF errors:

```
level=fatal msg="writing blob: Post \"https://default-route-openshift-image-registry.apps.<cluster>/v2/rhdh/rhdh-operator-bundle/blobs/uploads/\": EOF"
```

This was confirmed across multiple Prow CI runs (IDs `2076969364770263040`, `2076993843823120384`). The issue is infrastructure-specific to OSD-GCP clusters, not a code bug.

## Evidence the Fix Works

After applying this retry logic (along with `MAX_PARALLEL=3` on the RHDH CI side), the operator installed successfully on the first attempt in Prow run `2077016111739572224`:

- Zero `skopeo copy failed` errors
- Zero EOF errors from the internal registry
- Operator installed on first attempt (previously failed after 1-3 attempts)

## Related

- **RHDH CI PR**: redhat-developer/rhdh#4419 (temporary local copy workaround — can be removed once this PR is merged)
- **Jira**: [RHDHBUGS-1136](https://redhat.atlassian.net/browse/RHDHBUGS-1136)

## Test Plan

- [x] Existing CI jobs that use `install-rhdh-catalog-source.sh` continue to work (retry logic is transparent — succeeds on first attempt when registry is healthy)
- [x] OSD-GCP operator nightly job passes with this change
- [x] Verify `SKOPEO_RETRIES` and `SKOPEO_RETRY_DELAY` env vars override defaults correctly

Signed-off-by: Fortune Ndlovu <fndlovu@redhat.com>