### PR TITLE
fix: temporarily disable lightspeed due to DPDY issues in `next` catalog index image

### DIFF
--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2026-07-07T19:20:23Z"
+    createdAt: "2026-07-15T08:29:19Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.11
-    createdAt: "2026-07-07T19:20:26Z"
+    createdAt: "2026-07-15T08:29:22Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
@@ -328,7 +328,8 @@ data:
   metadata.yaml: |
     # Lightspeed (AI) flavour metadata
     # This flavour is enabled by default and provides AI/Lightspeed functionality
-    enabledByDefault: true
+    # FIXME: temporarily disabled due to DPDY issues; to re-enable in https://redhat.atlassian.net/browse/RHIDP-15458
+    enabledByDefault: false
 kind: ConfigMap
 metadata:
   name: rhdh-flavour-lightspeed-config

--- a/config/profile/rhdh/default-config/flavours/lightspeed/metadata.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/metadata.yaml
@@ -1,3 +1,4 @@
 # Lightspeed (AI) flavour metadata
 # This flavour is enabled by default and provides AI/Lightspeed functionality
-enabledByDefault: true
+# FIXME: temporarily disabled due to DPDY issues; to re-enable in https://redhat.atlassian.net/browse/RHIDP-15458
+enabledByDefault: false

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -3350,7 +3350,8 @@ data:
   metadata.yaml: |
     # Lightspeed (AI) flavour metadata
     # This flavour is enabled by default and provides AI/Lightspeed functionality
-    enabledByDefault: true
+    # FIXME: temporarily disabled due to DPDY issues; to re-enable in https://redhat.atlassian.net/browse/RHIDP-15458
+    enabledByDefault: false
 kind: ConfigMap
 metadata:
   name: rhdh-flavour-lightspeed-config

--- a/integration_tests/rhdh-config_test.go
+++ b/integration_tests/rhdh-config_test.go
@@ -276,11 +276,8 @@ var _ = When("create default rhdh", func() {
 			deploy, err := backstageDeployment(ctx, k8sClient, ns, backstageName)
 			g.Expect(err).To(Not(HaveOccurred()))
 
-			// no default flavour
-			// g.Expect(len(deploy.PodSpec().InitContainers)).To(Equal(1))
-
-			// with default lightspeed flavour
-			g.Expect(len(deploy.PodSpec().InitContainers)).To(Equal(2))
+			// FIXME: restore to Equal(2) when lightspeed is re-enabled (RHIDP-15458)
+			g.Expect(len(deploy.PodSpec().InitContainers)).To(Equal(1))
 
 			initCont := deploy.PodSpec().InitContainers[0]
 			g.Expect(initCont.Name).To(Equal("install-dynamic-plugins"))
@@ -298,6 +295,9 @@ var _ = When("create default rhdh", func() {
 	})
 
 	It("creates rhdh with default Lightspeed flavour", func() {
+
+		// FIXME: re-enable when lightspeed is re-enabled (RHIDP-15458)
+		Skip("Temporarily skipped: lightspeed disabled by default due to DPDY issues")
 
 		if !isProfile("rhdh") {
 			Skip("Skipped for non rhdh config")


### PR DESCRIPTION
## Description

For context, the issue is due to the fact that the LS plugins are referenced using ghcr.io in the DPDY (fallback mechanism for example for plugins that do not build against the expected version of Backstage).
As discussed, after the rename of the LS plugins, we'll be able to re-enable them.

## Which issue(s) does this PR fix or relate to

```
InstallException: Cannot use {{inherit}} for oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:
  no existing plugin configuration found. Ensure a plugin from this image is defined in an included file with an explicit version.
```

Relates to [RHIDP-15458](https://redhat.atlassian.net/browse/RHIDP-15458)

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Building Container Images for Testing

Need to test container images from this PR?

**For Maintainers:** To trigger a test image build, review the code and comment `/build-images`.
This always builds the HEAD of the PR branch.

**For Contributors:** Ask a maintainer to run `/build-images`.

Images will be built and pushed to Quay with links posted in comments.
