### PR TITLE
fix: wait for OLM v1 install readiness before success

### DIFF
--- a/.rhdh/docs/installing-ci-builds.adoc
+++ b/.rhdh/docs/installing-ci-builds.adoc
@@ -33,9 +33,7 @@ Besides the prerequisites listed above, you will also need:
 
 ==== Procedure
 
-. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator catalog resources in your cluster. By default, it installs the Release Candidate or GA version (from the `release-1.yy` branch), but the `--next` option allows to install the current development build (from the `main` branch).
-+
-The script auto-detects OLM v0 vs v1 from the ClusterExtension CRD (`--olm-version auto|v0|v1`). On OLM v1 it creates a `ClusterCatalog` / `ClusterExtension` and waits until the catalog is Serving and the extension is Installed (and for RHDH, until the `backstages.rhdh.redhat.com` CRD exists) before exiting successfully. On OpenShift, OLM v1 also merges internal-registry credentials into the cluster pull secret (`openshift-config/pull-secret`), matching the approach used by `prepare-restricted-environment.sh`, because catalogd authenticates via that global secret. On failure it prints diagnostics and exits non-zero. For example:
+. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator CatalogSource in your cluster. By default, it installs the Release Candidate or GA version (from the `release-1.yy` branch), but the `--next` option allows to install the current development build (from the `main` branch). The script auto-detects OLM v0 or v1 and waits for the operator to be ready before exiting. For example:
 +
 [source,console]
 ----
@@ -43,17 +41,14 @@ cd /tmp
 curl -sSLO https://raw.githubusercontent.com/redhat-developer/rhdh-operator/main/.rhdh/scripts/install-rhdh-catalog-source.sh
 chmod +x install-rhdh-catalog-source.sh
 
-# install catalog and operator, for the latest downstream stable, RC or GA build from the release-1.yy branch
-./install-rhdh-catalog-source.sh --latest --install-operator rhdh
+# install catalog source and operator subscription, for the latest downstream stable, RC or GA build from the release-1.yy branch
+./install-rhdh-catalog-source.sh --latest --install-operator rhdh  
 
-# OR, install catalog and operator, for the next downstream CI build from the main branch
-./install-rhdh-catalog-source.sh --next --install-operator rhdh
-
-# Force classic OLM v0 (CatalogSource + Subscription) if needed
-./install-rhdh-catalog-source.sh --next --install-operator rhdh --olm-version v0
+# OR, install catalog source and operator subscription, for the next donwstream CI build from the main branch
+./install-rhdh-catalog-source.sh --next --install-operator rhdh  
 ----
 
-. If you did not install the operator in the previous step (`--install-operator`), you can do so now. On OpenShift with OLM v0, open the *Administrator* perspective of the web console, then go to *Operators* → *OperatorHub*, search for Red Hat Developer Hub, and install the Red Hat Developer Hub Operator. For more info, see link:https://docs.openshift.com/container-platform/4.14/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console].
+. If you did not create a subscription in the previous step, you can do so now. On OpenShift, open the *Administrator* perspective of the web console, then go to *Operators* → *OperatorHub*, search for Red Hat Developer Hub, and install the Red Hat Developer Hub Operator. For more info, see link:https://docs.openshift.com/container-platform/4.14/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console].
 
 === Deploying RHDH
 

--- a/.rhdh/docs/installing-ci-builds.adoc
+++ b/.rhdh/docs/installing-ci-builds.adoc
@@ -33,7 +33,7 @@ Besides the prerequisites listed above, you will also need:
 
 ==== Procedure
 
-. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator CatalogSource in your cluster. By default, it installs the Release Candidate or GA version (from the `release-1.yy` branch), but the `--next` option allows to install the current development build (from the `main` branch). The script auto-detects OLM v0 or v1 and waits for the operator to be ready before exiting. For example:
+. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator CatalogSource in your cluster. By default, it installs the Release Candidate or GA version (from the `release-1.yy` branch), but the `--next` option allows to install the current development build (from the `main` branch). The script auto-detects OLM v0 or v1 and, with `--install-operator`, waits for catalog Serving, extension Installed, and the Backstage CRD Established before exiting. For example:
 +
 [source,console]
 ----

--- a/.rhdh/docs/installing-ci-builds.adoc
+++ b/.rhdh/docs/installing-ci-builds.adoc
@@ -33,7 +33,9 @@ Besides the prerequisites listed above, you will also need:
 
 ==== Procedure
 
-. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator CatalogSource in your cluster. By default, it installs the Release Candidate or GA version (from the `release-1.yy` branch), but the `--next` option allows to install the current development build (from the `main` branch). For example:
+. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator catalog resources in your cluster. By default, it installs the Release Candidate or GA version (from the `release-1.yy` branch), but the `--next` option allows to install the current development build (from the `main` branch).
++
+The script auto-detects OLM v0 vs v1 from the ClusterExtension CRD (`--olm-version auto|v0|v1`). On OLM v1 it creates a `ClusterCatalog` / `ClusterExtension` and waits until the catalog is Serving and the extension is Installed (and for RHDH, until the `backstages.rhdh.redhat.com` CRD exists) before exiting successfully. On failure it prints diagnostics and exits non-zero. For example:
 +
 [source,console]
 ----
@@ -41,14 +43,17 @@ cd /tmp
 curl -sSLO https://raw.githubusercontent.com/redhat-developer/rhdh-operator/main/.rhdh/scripts/install-rhdh-catalog-source.sh
 chmod +x install-rhdh-catalog-source.sh
 
-# install catalog source and operator subscription, for the latest downstream stable, RC or GA build from the release-1.yy branch
-./install-rhdh-catalog-source.sh --latest --install-operator rhdh  
+# install catalog and operator, for the latest downstream stable, RC or GA build from the release-1.yy branch
+./install-rhdh-catalog-source.sh --latest --install-operator rhdh
 
-# OR, install catalog source and operator subscription, for the next donwstream CI build from the main branch
-./install-rhdh-catalog-source.sh --next --install-operator rhdh  
+# OR, install catalog and operator, for the next downstream CI build from the main branch
+./install-rhdh-catalog-source.sh --next --install-operator rhdh
+
+# Force classic OLM v0 (CatalogSource + Subscription) if needed
+./install-rhdh-catalog-source.sh --next --install-operator rhdh --olm-version v0
 ----
 
-. If you did not create a subscription in the previous step, you can do so now. On OpenShift, open the *Administrator* perspective of the web console, then go to *Operators* → *OperatorHub*, search for Red Hat Developer Hub, and install the Red Hat Developer Hub Operator. For more info, see link:https://docs.openshift.com/container-platform/4.14/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console].
+. If you did not install the operator in the previous step (`--install-operator`), you can do so now. On OpenShift with OLM v0, open the *Administrator* perspective of the web console, then go to *Operators* → *OperatorHub*, search for Red Hat Developer Hub, and install the Red Hat Developer Hub Operator. For more info, see link:https://docs.openshift.com/container-platform/4.14/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console].
 
 === Deploying RHDH
 

--- a/.rhdh/docs/installing-ci-builds.adoc
+++ b/.rhdh/docs/installing-ci-builds.adoc
@@ -35,7 +35,7 @@ Besides the prerequisites listed above, you will also need:
 
 . Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator catalog resources in your cluster. By default, it installs the Release Candidate or GA version (from the `release-1.yy` branch), but the `--next` option allows to install the current development build (from the `main` branch).
 +
-The script auto-detects OLM v0 vs v1 from the ClusterExtension CRD (`--olm-version auto|v0|v1`). On OLM v1 it creates a `ClusterCatalog` / `ClusterExtension` and waits until the catalog is Serving and the extension is Installed (and for RHDH, until the `backstages.rhdh.redhat.com` CRD exists) before exiting successfully. On failure it prints diagnostics and exits non-zero. For example:
+The script auto-detects OLM v0 vs v1 from the ClusterExtension CRD (`--olm-version auto|v0|v1`). On OLM v1 it creates a `ClusterCatalog` / `ClusterExtension` and waits until the catalog is Serving and the extension is Installed (and for RHDH, until the `backstages.rhdh.redhat.com` CRD exists) before exiting successfully. On OpenShift, OLM v1 also merges internal-registry credentials into the cluster pull secret (`openshift-config/pull-secret`), matching the approach used by `prepare-restricted-environment.sh`, because catalogd authenticates via that global secret. On failure it prints diagnostics and exits non-zero. For example:
 +
 [source,console]
 ----

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -185,6 +185,82 @@ function dump_olm_v1_diagnostics() {
   errorf "===== end OLM v1 diagnostics ====="
 }
 
+# Align with prepare-restricted-environment.sh prepare_olm_v1_secrets:
+# OLM v1 catalogd authenticates via openshift-config/pull-secret (--global-pull-secret),
+# not ClusterCatalog pullSecret fields or image-puller alone.
+function prepare_olm_v1_secrets() {
+  set -euo pipefail
+
+  local catalogd_ns="$1"
+  local controller_ns="$2"
+  local image_namespace="${3:-rhdh}"
+
+  if [[ "${IS_OPENSHIFT}" != "true" ]]; then
+    return 0
+  fi
+
+  local internal_registry_url="image-registry.openshift-image-registry.svc:5000"
+  local external_registry_url
+  external_registry_url=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}' 2>/dev/null || true)
+  if [[ -z "${external_registry_url}" ]]; then
+    errorf "Could not resolve OpenShift internal registry default route; is the registry exposed?"
+    return 1
+  fi
+
+  local token
+  token=$(oc whoami -t)
+  # macOS base64 has no -w0; Linux does. Strip newlines for both.
+  local internal_auth
+  internal_auth=$(echo -n "kubeadmin:${token}" | base64 | tr -d '\n')
+
+  local existing_pull_secret
+  existing_pull_secret=$(oc get secret pull-secret -n openshift-config -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d)
+
+  local merged
+  merged=$(echo "${existing_pull_secret}" | jq \
+    --arg url1 "${internal_registry_url}" \
+    --arg url2 "${external_registry_url}" \
+    --arg auth "${internal_auth}" \
+    '.auths[$url1] = {auth: $auth} | .auths[$url2] = {auth: $auth}')
+
+  echo "${merged}" | oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=/dev/stdin >&2
+  infof "Merged internal registry credentials into global pull secret (openshift-config/pull-secret)"
+
+  # Namespace-scoped secrets for the operator/installer SA (marketplace secrets already created by ocp_install).
+  if ! invoke_cluster_cli get namespace "${NAMESPACE_SUBSCRIPTION}" &>/dev/null; then
+    invoke_cluster_cli create namespace "${NAMESPACE_SUBSCRIPTION}" >&2
+  fi
+  invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" delete secret internal-reg-ext-auth-for-rhdh --ignore-not-found >&2
+  invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" create secret docker-registry internal-reg-ext-auth-for-rhdh \
+    --docker-server="${external_registry_url}" \
+    --docker-username=kubeadmin \
+    --docker-password="${token}" \
+    --docker-email="admin@internal-registry-ext.example.com" >&2
+  invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" delete secret internal-reg-auth-for-rhdh --ignore-not-found >&2
+  invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" create secret docker-registry internal-reg-auth-for-rhdh \
+    --docker-server="${internal_registry_url}" \
+    --docker-username=kubeadmin \
+    --docker-password="${token}" \
+    --docker-email="admin@internal-registry.example.com" >&2
+
+  local catalogd_sa
+  catalogd_sa=$(invoke_cluster_cli get deployment -n "${catalogd_ns}" -l 'app.kubernetes.io/name=catalogd' \
+    -o jsonpath='{.items[0].spec.template.spec.serviceAccountName}' 2>/dev/null || true)
+  catalogd_sa="${catalogd_sa:-catalogd-controller-manager}"
+
+  local controller_sa
+  controller_sa=$(invoke_cluster_cli get deployment -n "${controller_ns}" -l 'app.kubernetes.io/name=operator-controller' \
+    -o jsonpath='{.items[0].spec.template.spec.serviceAccountName}' 2>/dev/null || true)
+  controller_sa="${controller_sa:-operator-controller-controller-manager}"
+
+  debugf "Granting image-puller in namespace '${image_namespace}' to OLM v1 service accounts"
+  if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${catalogd_ns}:${catalogd_sa}" -n "${image_namespace}" || \
+     ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${controller_ns}:${controller_sa}" -n "${image_namespace}"; then
+    errorf "Failed to grant image-puller to OLM v1 controller SAs in namespace ${image_namespace}"
+    return 1
+  fi
+}
+
 function render_iib() {
   set -euo pipefail
 
@@ -1040,20 +1116,9 @@ if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
   fi
   debugf "Using operator-controller namespace: ${NAMESPACE_OLM_CONTROLLER}"
 
-  # Grant image-puller access so OLM v1 can pull rebuilt IIBs from the internal registry
-  if [[ "${IS_OPENSHIFT}" = "true" ]]; then
-    CATALOGD_SA=$(invoke_cluster_cli get deployment -n "${NAMESPACE_CATALOGD}" -l 'app.kubernetes.io/name=catalogd' \
-      -o jsonpath='{.items[0].spec.template.spec.serviceAccountName}' 2>/dev/null || true)
-    CATALOGD_SA="${CATALOGD_SA:-catalogd-controller-manager}"
-    CONTROLLER_SA=$(invoke_cluster_cli get deployment -n "${NAMESPACE_OLM_CONTROLLER}" -l 'app.kubernetes.io/name=operator-controller' \
-      -o jsonpath='{.items[0].spec.template.spec.serviceAccountName}' 2>/dev/null || true)
-    CONTROLLER_SA="${CONTROLLER_SA:-operator-controller-controller-manager}"
-    if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_CATALOGD}:${CATALOGD_SA}" -n rhdh || \
-       ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_OLM_CONTROLLER}:${CONTROLLER_SA}" -n rhdh; then
-      errorf "Failed to grant image-puller to OLM v1 controller SAs in namespace rhdh"
-      dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "" "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
-      exit 1
-    fi
+  if ! prepare_olm_v1_secrets "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}" "rhdh"; then
+    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "" "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+    exit 1
   fi
 
   # Delete existing ClusterCatalog to force re-index
@@ -1074,7 +1139,7 @@ spec:
 
   infof "Waiting for ClusterCatalog/${CATALOGSOURCE_NAME} Serving (timeout ${OLM_V1_WAIT_TIMEOUT}s)..."
   if ! invoke_cluster_cli wait "clustercatalog/${CATALOGSOURCE_NAME}" --for=condition=Serving --timeout="${OLM_V1_WAIT_TIMEOUT}s"; then
-    errorf "ClusterCatalog/${CATALOGSOURCE_NAME} did not become Serving within ${OLM_V1_WAIT_TIMEOUT}s (check image-puller RBAC if on OpenShift)"
+    errorf "ClusterCatalog/${CATALOGSOURCE_NAME} did not become Serving within ${OLM_V1_WAIT_TIMEOUT}s (check openshift-config/pull-secret and image-puller RBAC if on OpenShift)"
     dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "" "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
     exit 1
   fi

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -16,8 +16,6 @@ UPSTREAM_IIB_OVERRIDE=""
 INSTALL_PLAN_APPROVAL="Automatic"
 OLM_VERSION="auto"
 RESOLVED_OLM_VERSION=""
-# Timeout (seconds) for OLM v1 readiness waits (ClusterCatalog Serving, ClusterExtension Installed, CRD).
-OLM_V1_WAIT_TIMEOUT="${OLM_V1_WAIT_TIMEOUT:-300}"
 MAX_PARALLEL="${MAX_PARALLEL:-10}"
 if ! [[ "$MAX_PARALLEL" =~ ^[0-9]+$ ]] || [[ "$MAX_PARALLEL" -lt 1 ]]; then
   echo "[ERROR] MAX_PARALLEL must be a positive integer, got: '$MAX_PARALLEL'" >&2
@@ -200,12 +198,9 @@ function prepare_olm_v1_secrets() {
   fi
 
   local internal_registry_url="image-registry.openshift-image-registry.svc:5000"
+  # External route is optional; ClusterCatalog pulls via the internal svc URL.
   local external_registry_url
   external_registry_url=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}' 2>/dev/null || true)
-  if [[ -z "${external_registry_url}" ]]; then
-    errorf "Could not resolve OpenShift internal registry default route; is the registry exposed?"
-    return 1
-  fi
 
   local token
   token=$(oc whoami -t)
@@ -218,10 +213,17 @@ function prepare_olm_v1_secrets() {
 
   local merged
   merged=$(echo "${existing_pull_secret}" | jq \
-    --arg url1 "${internal_registry_url}" \
-    --arg url2 "${external_registry_url}" \
+    --arg url "${internal_registry_url}" \
     --arg auth "${internal_auth}" \
-    '.auths[$url1] = {auth: $auth} | .auths[$url2] = {auth: $auth}')
+    '.auths[$url] = {auth: $auth}')
+  if [[ -n "${external_registry_url}" ]]; then
+    merged=$(echo "${merged}" | jq \
+      --arg url "${external_registry_url}" \
+      --arg auth "${internal_auth}" \
+      '.auths[$url] = {auth: $auth}')
+  else
+    warnf "OpenShift registry default-route not found; merged credentials for ${internal_registry_url} only"
+  fi
 
   echo "${merged}" | oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=/dev/stdin >&2
   infof "Merged internal registry credentials into global pull secret (openshift-config/pull-secret)"
@@ -230,18 +232,20 @@ function prepare_olm_v1_secrets() {
   if ! invoke_cluster_cli get namespace "${NAMESPACE_SUBSCRIPTION}" &>/dev/null; then
     invoke_cluster_cli create namespace "${NAMESPACE_SUBSCRIPTION}" >&2
   fi
-  invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" delete secret internal-reg-ext-auth-for-rhdh --ignore-not-found >&2
-  invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" create secret docker-registry internal-reg-ext-auth-for-rhdh \
-    --docker-server="${external_registry_url}" \
-    --docker-username=kubeadmin \
-    --docker-password="${token}" \
-    --docker-email="admin@internal-registry-ext.example.com" >&2
   invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" delete secret internal-reg-auth-for-rhdh --ignore-not-found >&2
   invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" create secret docker-registry internal-reg-auth-for-rhdh \
     --docker-server="${internal_registry_url}" \
     --docker-username=kubeadmin \
     --docker-password="${token}" \
     --docker-email="admin@internal-registry.example.com" >&2
+  if [[ -n "${external_registry_url}" ]]; then
+    invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" delete secret internal-reg-ext-auth-for-rhdh --ignore-not-found >&2
+    invoke_cluster_cli -n "${NAMESPACE_SUBSCRIPTION}" create secret docker-registry internal-reg-ext-auth-for-rhdh \
+      --docker-server="${external_registry_url}" \
+      --docker-username=kubeadmin \
+      --docker-password="${token}" \
+      --docker-email="admin@internal-registry-ext.example.com" >&2
+  fi
 
   local catalogd_sa
   catalogd_sa=$(invoke_cluster_cli get deployment -n "${catalogd_ns}" -l 'app.kubernetes.io/name=catalogd' \
@@ -1137,9 +1141,9 @@ spec:
       ref: ${newIIBImage}
 " > "$TMPDIR"/ClusterCatalog.yml && invoke_cluster_cli apply -f "$TMPDIR"/ClusterCatalog.yml
 
-  infof "Waiting for ClusterCatalog/${CATALOGSOURCE_NAME} Serving (timeout ${OLM_V1_WAIT_TIMEOUT}s)..."
-  if ! invoke_cluster_cli wait "clustercatalog/${CATALOGSOURCE_NAME}" --for=condition=Serving --timeout="${OLM_V1_WAIT_TIMEOUT}s"; then
-    errorf "ClusterCatalog/${CATALOGSOURCE_NAME} did not become Serving within ${OLM_V1_WAIT_TIMEOUT}s (check openshift-config/pull-secret and image-puller RBAC if on OpenShift)"
+  infof "Waiting for ClusterCatalog/${CATALOGSOURCE_NAME} Serving (timeout 300s)..."
+  if ! invoke_cluster_cli wait "clustercatalog/${CATALOGSOURCE_NAME}" --for=condition=Serving --timeout=300s; then
+    errorf "ClusterCatalog/${CATALOGSOURCE_NAME} did not become Serving within 300s (check openshift-config/pull-secret and image-puller RBAC if on OpenShift)"
     dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "" "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
     exit 1
   fi
@@ -1217,9 +1221,9 @@ spec:
         enforcement: None
 " > "$TMPDIR"/ClusterExtension.yml && invoke_cluster_cli apply -f "$TMPDIR"/ClusterExtension.yml
 
-  infof "Waiting for ClusterExtension/${OPERATOR_NAME_TO_INSTALL} Installed (timeout ${OLM_V1_WAIT_TIMEOUT}s)..."
-  if ! invoke_cluster_cli wait "clusterextension/${OPERATOR_NAME_TO_INSTALL}" --for=condition=Installed --timeout="${OLM_V1_WAIT_TIMEOUT}s"; then
-    errorf "ClusterExtension/${OPERATOR_NAME_TO_INSTALL} did not become Installed within ${OLM_V1_WAIT_TIMEOUT}s"
+  infof "Waiting for ClusterExtension/${OPERATOR_NAME_TO_INSTALL} Installed (timeout 300s)..."
+  if ! invoke_cluster_cli wait "clusterextension/${OPERATOR_NAME_TO_INSTALL}" --for=condition=Installed --timeout=300s; then
+    errorf "ClusterExtension/${OPERATOR_NAME_TO_INSTALL} did not become Installed within 300s"
     dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}" \
       "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
     exit 1
@@ -1227,8 +1231,8 @@ spec:
 
   # When installing RHDH, also wait for the Backstage CRD before reporting success.
   if [[ "${OPERATOR_NAME_IN_CS}" == "rhdh" || "${OPERATOR_NAME_TO_INSTALL}" == "rhdh" ]]; then
-    infof "Waiting for CRD backstages.rhdh.redhat.com (timeout ${OLM_V1_WAIT_TIMEOUT}s)..."
-    deadline=$((SECONDS + OLM_V1_WAIT_TIMEOUT))
+    infof "Waiting for CRD backstages.rhdh.redhat.com (timeout 300s)..."
+    deadline=$((SECONDS + 300))
     while (( SECONDS < deadline )); do
       if invoke_cluster_cli get crd backstages.rhdh.redhat.com &>/dev/null; then
         break
@@ -1236,7 +1240,7 @@ spec:
       sleep 5
     done
     if ! invoke_cluster_cli get crd backstages.rhdh.redhat.com &>/dev/null; then
-      errorf "CRD backstages.rhdh.redhat.com was not created within ${OLM_V1_WAIT_TIMEOUT}s"
+      errorf "CRD backstages.rhdh.redhat.com was not created within 300s"
       dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}" \
         "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
       exit 1

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -58,11 +58,9 @@ function usage() {
 This script streamlines testing IIB images by configuring an OpenShift or Kubernetes cluster to enable it to use the specified IIB image
 as a catalog source. On OLM v0, a CatalogSource is created in 'openshift-marketplace' (OpenShift) or 'olm' (Kubernetes). On OLM v1,
 a ClusterCatalog is created (cluster-scoped); when --install-operator is also provided, a ClusterExtension, ServiceAccount, and
-ClusterRoleBinding are created in the '${NAMESPACE_SUBSCRIPTION}' namespace. The script waits for ClusterCatalog Serving and
-(when installing) ClusterExtension Installed before exiting successfully. By default, the OLM version is auto-detected based on
-the presence of the ClusterExtension CRD (prefers v1 when present, on both OpenShift and Kubernetes). The default
-catalog/resource name is 'operatorName-channelName' (eg., rhdh-fast), or 'brew-registry-stage' when using --catalog-source
-with a brew IIB override
+ClusterRoleBinding are created in the '${NAMESPACE_SUBSCRIPTION}' namespace. By default, the OLM version is auto-detected based on
+the presence of the ClusterExtension CRD. When installing an operator, the script waits for readiness before exiting successfully.
+The default catalog/resource name is 'operatorName-channelName' (eg., rhdh-fast).
 
 If IIB installation fails, see https://docs.engineering.redhat.com/display/CFC/Test and
 follow steps in section 'Adding Brew Pull Secret'
@@ -75,9 +73,9 @@ Options:
   --latest                            : Install from iib quay.io/rhdh/iib:latest-\$OCP_VER-\$OCP_ARCH (eg., latest-v4.14-x86_64) [default]
   --next                              : Install from iib quay.io/rhdh/iib:next-\$OCP_VER-\$OCP_ARCH (eg., next-v4.14-x86_64)
   --catalog-source                    : Install from specified catalog source, like brew.registry.redhat.io/rh-osbs/iib-pub-pending:v4.18
-  --install-operator <NAME>           : Install operator named \$NAME after creating catalog resources
-  --install-plan-approval <STRATEGY>  : Specify the install plan strategy for the subscription (default: Automatic; OLM v0 only)
-  --olm-version v0|v1|auto            : Force OLM version for catalog/operator resources (default: auto-detect via ClusterExtension CRD)
+  --install-operator <NAME>           : Install operator named \$NAME after creating CatalogSource
+  --install-plan-approval <STRATEGY>  : Specify the install plan strategy for the subscription (default: Automatic)
+  --olm-version v0|v1|auto            : Force OLM version for catalog/operator resources (default: auto-detect)
 
 Examples:
   $0 \\
@@ -158,11 +156,10 @@ function resolve_olm_version() {
   fi
 }
 
+# On failure, print ClusterCatalog / ClusterExtension status so CI logs show why Serving/Installed never became True.
 function dump_olm_v1_diagnostics() {
   local catalog_name="${1:-}"
   local extension_name="${2:-}"
-  local catalogd_ns="${3:-}"
-  local controller_ns="${4:-}"
 
   errorf "===== OLM v1 diagnostics ====="
   [[ -n "${catalog_name}" ]] && invoke_cluster_cli describe clustercatalog "${catalog_name}" 2>&1 || true
@@ -171,19 +168,9 @@ function dump_olm_v1_diagnostics() {
     invoke_cluster_cli get clusterextension "${extension_name}" -o jsonpath='{.status.conditions}' 2>&1 || true
     echo
   fi
-  if [[ -n "${catalogd_ns}" ]]; then
-    invoke_cluster_cli get events -n "${catalogd_ns}" --sort-by='.lastTimestamp' 2>&1 | tail -n 20 || true
-    invoke_cluster_cli logs -n "${catalogd_ns}" -l 'app.kubernetes.io/name=catalogd' --tail=50 2>&1 || true
-  fi
-  if [[ -n "${controller_ns}" ]]; then
-    invoke_cluster_cli get events -n "${controller_ns}" --sort-by='.lastTimestamp' 2>&1 | tail -n 20 || true
-    invoke_cluster_cli logs -n "${controller_ns}" -l 'app.kubernetes.io/name=operator-controller' --tail=50 2>&1 || true
-  fi
-  invoke_cluster_cli get pods -n "${NAMESPACE_SUBSCRIPTION}" -o wide 2>&1 || true
   errorf "===== end OLM v1 diagnostics ====="
 }
 
-# Align with prepare-restricted-environment.sh prepare_olm_v1_secrets:
 # OLM v1 catalogd authenticates via openshift-config/pull-secret (--global-pull-secret),
 # not ClusterCatalog pullSecret fields or image-puller alone.
 function prepare_olm_v1_secrets() {
@@ -270,14 +257,11 @@ function render_iib() {
 
   mkdir -p "${TMPDIR}/rhdh/rhdh"
   debugf "Rendering IIB $UPSTREAM_IIB as a local file..."
-  if ! opm render "$UPSTREAM_IIB" --output=yaml > "${TMPDIR}/rhdh/rhdh/render.yaml"; then
-    errorf "'opm render ${UPSTREAM_IIB}' failed. Try: skopeo inspect docker://${UPSTREAM_IIB}"
-    return 1
-  fi
+  opm render "$UPSTREAM_IIB" --output=yaml > "${TMPDIR}/rhdh/rhdh/render.yaml"
   if [ ! -s "${TMPDIR}/rhdh/rhdh/render.yaml" ]; then
     errorf "
-[ERROR] 'opm render ${UPSTREAM_IIB}' returned an empty output, which likely means that this IIB Image does not contain any operators in it.
-Try: skopeo inspect docker://${UPSTREAM_IIB} — then retry, or reach out to the RHDH Productization team.
+[ERROR] 'opm render $UPSTREAM_IIB' returned an empty output, which likely means that this IIB Image does not contain any operators in it.
+Please reach out to the RHDH Productization team.
 "
     return 1
   fi
@@ -1121,7 +1105,7 @@ if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
   debugf "Using operator-controller namespace: ${NAMESPACE_OLM_CONTROLLER}"
 
   if ! prepare_olm_v1_secrets "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}" "rhdh"; then
-    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "" "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}"
     exit 1
   fi
 
@@ -1144,7 +1128,7 @@ spec:
   infof "Waiting for ClusterCatalog/${CATALOGSOURCE_NAME} Serving (timeout 300s)..."
   if ! invoke_cluster_cli wait "clustercatalog/${CATALOGSOURCE_NAME}" --for=condition=Serving --timeout=300s; then
     errorf "ClusterCatalog/${CATALOGSOURCE_NAME} did not become Serving within 300s (check openshift-config/pull-secret and image-puller RBAC if on OpenShift)"
-    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "" "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}"
     exit 1
   fi
 
@@ -1191,8 +1175,7 @@ subjects:
   if [[ "${IS_OPENSHIFT}" = "true" ]]; then
     if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_SUBSCRIPTION}:${SA_NAME}" -n rhdh; then
       errorf "Failed to grant image-puller to installer SA '${SA_NAME}' in namespace rhdh"
-      dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}" \
-        "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+      dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}"
       exit 1
     fi
   fi
@@ -1224,8 +1207,7 @@ spec:
   infof "Waiting for ClusterExtension/${OPERATOR_NAME_TO_INSTALL} Installed (timeout 300s)..."
   if ! invoke_cluster_cli wait "clusterextension/${OPERATOR_NAME_TO_INSTALL}" --for=condition=Installed --timeout=300s; then
     errorf "ClusterExtension/${OPERATOR_NAME_TO_INSTALL} did not become Installed within 300s"
-    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}" \
-      "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}"
     exit 1
   fi
 
@@ -1241,8 +1223,7 @@ spec:
     done
     if ! invoke_cluster_cli get crd backstages.rhdh.redhat.com &>/dev/null; then
       errorf "CRD backstages.rhdh.redhat.com was not created within 300s"
-      dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}" \
-        "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+      dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}"
       exit 1
     fi
   fi

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -16,6 +16,8 @@ UPSTREAM_IIB_OVERRIDE=""
 INSTALL_PLAN_APPROVAL="Automatic"
 OLM_VERSION="auto"
 RESOLVED_OLM_VERSION=""
+# Timeout (seconds) for OLM v1 readiness waits (ClusterCatalog Serving, ClusterExtension Installed, CRD).
+OLM_V1_WAIT_TIMEOUT="${OLM_V1_WAIT_TIMEOUT:-300}"
 MAX_PARALLEL="${MAX_PARALLEL:-10}"
 if ! [[ "$MAX_PARALLEL" =~ ^[0-9]+$ ]] || [[ "$MAX_PARALLEL" -lt 1 ]]; then
   echo "[ERROR] MAX_PARALLEL must be a positive integer, got: '$MAX_PARALLEL'" >&2
@@ -58,9 +60,11 @@ function usage() {
 This script streamlines testing IIB images by configuring an OpenShift or Kubernetes cluster to enable it to use the specified IIB image
 as a catalog source. On OLM v0, a CatalogSource is created in 'openshift-marketplace' (OpenShift) or 'olm' (Kubernetes). On OLM v1,
 a ClusterCatalog is created (cluster-scoped); when --install-operator is also provided, a ClusterExtension, ServiceAccount, and
-ClusterRoleBinding are created in the '${NAMESPACE_SUBSCRIPTION}' namespace. By default, the OLM version is auto-detected based on
-the presence of the ClusterExtension CRD. The default catalog/resource name is 'operatorName-channelName' (eg., rhdh-fast),
-or 'brew-registry-stage' when using --catalog-source with a brew IIB override
+ClusterRoleBinding are created in the '${NAMESPACE_SUBSCRIPTION}' namespace. The script waits for ClusterCatalog Serving and
+(when installing) ClusterExtension Installed before exiting successfully. By default, the OLM version is auto-detected based on
+the presence of the ClusterExtension CRD (prefers v1 when present, on both OpenShift and Kubernetes). The default
+catalog/resource name is 'operatorName-channelName' (eg., rhdh-fast), or 'brew-registry-stage' when using --catalog-source
+with a brew IIB override
 
 If IIB installation fails, see https://docs.engineering.redhat.com/display/CFC/Test and
 follow steps in section 'Adding Brew Pull Secret'
@@ -73,9 +77,9 @@ Options:
   --latest                            : Install from iib quay.io/rhdh/iib:latest-\$OCP_VER-\$OCP_ARCH (eg., latest-v4.14-x86_64) [default]
   --next                              : Install from iib quay.io/rhdh/iib:next-\$OCP_VER-\$OCP_ARCH (eg., next-v4.14-x86_64)
   --catalog-source                    : Install from specified catalog source, like brew.registry.redhat.io/rh-osbs/iib-pub-pending:v4.18
-  --install-operator <NAME>           : Install operator named \$NAME after creating CatalogSource
-  --install-plan-approval <STRATEGY>  : Specify the install plan strategy for the subscription (default: Automatic)
-  --olm-version v0|v1|auto            : Force OLM version for catalog/operator resources (default: auto-detect)
+  --install-operator <NAME>           : Install operator named \$NAME after creating catalog resources
+  --install-plan-approval <STRATEGY>  : Specify the install plan strategy for the subscription (default: Automatic; OLM v0 only)
+  --olm-version v0|v1|auto            : Force OLM version for catalog/operator resources (default: auto-detect via ClusterExtension CRD)
 
 Examples:
   $0 \\
@@ -156,16 +160,44 @@ function resolve_olm_version() {
   fi
 }
 
+function dump_olm_v1_diagnostics() {
+  local catalog_name="${1:-}"
+  local extension_name="${2:-}"
+  local catalogd_ns="${3:-}"
+  local controller_ns="${4:-}"
+
+  errorf "===== OLM v1 diagnostics ====="
+  [[ -n "${catalog_name}" ]] && invoke_cluster_cli describe clustercatalog "${catalog_name}" 2>&1 || true
+  if [[ -n "${extension_name}" ]]; then
+    invoke_cluster_cli describe clusterextension "${extension_name}" 2>&1 || true
+    invoke_cluster_cli get clusterextension "${extension_name}" -o jsonpath='{.status.conditions}' 2>&1 || true
+    echo
+  fi
+  if [[ -n "${catalogd_ns}" ]]; then
+    invoke_cluster_cli get events -n "${catalogd_ns}" --sort-by='.lastTimestamp' 2>&1 | tail -n 20 || true
+    invoke_cluster_cli logs -n "${catalogd_ns}" -l 'app.kubernetes.io/name=catalogd' --tail=50 2>&1 || true
+  fi
+  if [[ -n "${controller_ns}" ]]; then
+    invoke_cluster_cli get events -n "${controller_ns}" --sort-by='.lastTimestamp' 2>&1 | tail -n 20 || true
+    invoke_cluster_cli logs -n "${controller_ns}" -l 'app.kubernetes.io/name=operator-controller' --tail=50 2>&1 || true
+  fi
+  invoke_cluster_cli get pods -n "${NAMESPACE_SUBSCRIPTION}" -o wide 2>&1 || true
+  errorf "===== end OLM v1 diagnostics ====="
+}
+
 function render_iib() {
   set -euo pipefail
 
   mkdir -p "${TMPDIR}/rhdh/rhdh"
   debugf "Rendering IIB $UPSTREAM_IIB as a local file..."
-  opm render "$UPSTREAM_IIB" --output=yaml > "${TMPDIR}/rhdh/rhdh/render.yaml"
+  if ! opm render "$UPSTREAM_IIB" --output=yaml > "${TMPDIR}/rhdh/rhdh/render.yaml"; then
+    errorf "'opm render ${UPSTREAM_IIB}' failed. Try: skopeo inspect docker://${UPSTREAM_IIB}"
+    return 1
+  fi
   if [ ! -s "${TMPDIR}/rhdh/rhdh/render.yaml" ]; then
     errorf "
-[ERROR] 'opm render $UPSTREAM_IIB' returned an empty output, which likely means that this IIB Image does not contain any operators in it.
-Please reach out to the RHDH Productization team.
+[ERROR] 'opm render ${UPSTREAM_IIB}' returned an empty output, which likely means that this IIB Image does not contain any operators in it.
+Try: skopeo inspect docker://${UPSTREAM_IIB} — then retry, or reach out to the RHDH Productization team.
 "
     return 1
   fi
@@ -1008,12 +1040,20 @@ if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
   fi
   debugf "Using operator-controller namespace: ${NAMESPACE_OLM_CONTROLLER}"
 
-  # Grant image-puller access to OLM v1 controller SAs so they can pull images from the internal registry
+  # Grant image-puller access so OLM v1 can pull rebuilt IIBs from the internal registry
   if [[ "${IS_OPENSHIFT}" = "true" ]]; then
-    oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_CATALOGD}:catalogd-controller-manager" -n rhdh ||
-      warnf "Failed to grant image-puller to catalogd SA; catalog image pulls from internal registry may fail"
-    oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_OLM_CONTROLLER}:operator-controller-controller-manager" -n rhdh ||
-      warnf "Failed to grant image-puller to operator-controller SA; operator image pulls from internal registry may fail"
+    CATALOGD_SA=$(invoke_cluster_cli get deployment -n "${NAMESPACE_CATALOGD}" -l 'app.kubernetes.io/name=catalogd' \
+      -o jsonpath='{.items[0].spec.template.spec.serviceAccountName}' 2>/dev/null || true)
+    CATALOGD_SA="${CATALOGD_SA:-catalogd-controller-manager}"
+    CONTROLLER_SA=$(invoke_cluster_cli get deployment -n "${NAMESPACE_OLM_CONTROLLER}" -l 'app.kubernetes.io/name=operator-controller' \
+      -o jsonpath='{.items[0].spec.template.spec.serviceAccountName}' 2>/dev/null || true)
+    CONTROLLER_SA="${CONTROLLER_SA:-operator-controller-controller-manager}"
+    if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_CATALOGD}:${CATALOGD_SA}" -n rhdh || \
+       ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_OLM_CONTROLLER}:${CONTROLLER_SA}" -n rhdh; then
+      errorf "Failed to grant image-puller to OLM v1 controller SAs in namespace rhdh"
+      dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "" "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+      exit 1
+    fi
   fi
 
   # Delete existing ClusterCatalog to force re-index
@@ -1023,6 +1063,8 @@ if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
 kind: ClusterCatalog
 metadata:
   name: ${CATALOGSOURCE_NAME}
+  labels:
+    olm.operatorframework.io/metadata.name: ${CATALOGSOURCE_NAME}
 spec:
   source:
     type: Image
@@ -1030,9 +1072,16 @@ spec:
       ref: ${newIIBImage}
 " > "$TMPDIR"/ClusterCatalog.yml && invoke_cluster_cli apply -f "$TMPDIR"/ClusterCatalog.yml
 
+  infof "Waiting for ClusterCatalog/${CATALOGSOURCE_NAME} Serving (timeout ${OLM_V1_WAIT_TIMEOUT}s)..."
+  if ! invoke_cluster_cli wait "clustercatalog/${CATALOGSOURCE_NAME}" --for=condition=Serving --timeout="${OLM_V1_WAIT_TIMEOUT}s"; then
+    errorf "ClusterCatalog/${CATALOGSOURCE_NAME} did not become Serving within ${OLM_V1_WAIT_TIMEOUT}s (check image-puller RBAC if on OpenShift)"
+    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "" "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+    exit 1
+  fi
+
   if [[ -z "${TO_INSTALL}" ]]; then
     echo
-    echo "Done. ClusterCatalog '${CATALOGSOURCE_NAME}' created."
+    echo "Done. ClusterCatalog '${CATALOGSOURCE_NAME}' is Serving."
     echo "To install the operator, create a ClusterExtension, ServiceAccount, and ClusterRoleBinding."
     exit 0
   fi
@@ -1070,10 +1119,13 @@ subjects:
   namespace: ${NAMESPACE_SUBSCRIPTION}
 " > "$TMPDIR"/ClusterRoleBinding.yml && invoke_cluster_cli apply -f "$TMPDIR"/ClusterRoleBinding.yml
 
-  # Grant installer SA image-puller access so it can pull operator images from the internal registry
   if [[ "${IS_OPENSHIFT}" = "true" ]]; then
-    oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_SUBSCRIPTION}:${SA_NAME}" -n rhdh ||
-      warnf "Failed to grant image-puller to installer SA '${SA_NAME}'; operator image pulls from internal registry may fail"
+    if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_SUBSCRIPTION}:${SA_NAME}" -n rhdh; then
+      errorf "Failed to grant image-puller to installer SA '${SA_NAME}' in namespace rhdh"
+      dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}" \
+        "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+      exit 1
+    fi
   fi
 
   # Create ClusterExtension
@@ -1094,13 +1146,43 @@ spec:
       selector:
         matchLabels:
           olm.operatorframework.io/metadata.name: ${CATALOGSOURCE_NAME}
+  install:
+    preflight:
+      crdUpgradeSafety:
+        enforcement: None
 " > "$TMPDIR"/ClusterExtension.yml && invoke_cluster_cli apply -f "$TMPDIR"/ClusterExtension.yml
+
+  infof "Waiting for ClusterExtension/${OPERATOR_NAME_TO_INSTALL} Installed (timeout ${OLM_V1_WAIT_TIMEOUT}s)..."
+  if ! invoke_cluster_cli wait "clusterextension/${OPERATOR_NAME_TO_INSTALL}" --for=condition=Installed --timeout="${OLM_V1_WAIT_TIMEOUT}s"; then
+    errorf "ClusterExtension/${OPERATOR_NAME_TO_INSTALL} did not become Installed within ${OLM_V1_WAIT_TIMEOUT}s"
+    dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}" \
+      "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+    exit 1
+  fi
+
+  # When installing RHDH, also wait for the Backstage CRD before reporting success.
+  if [[ "${OPERATOR_NAME_IN_CS}" == "rhdh" || "${OPERATOR_NAME_TO_INSTALL}" == "rhdh" ]]; then
+    infof "Waiting for CRD backstages.rhdh.redhat.com (timeout ${OLM_V1_WAIT_TIMEOUT}s)..."
+    deadline=$((SECONDS + OLM_V1_WAIT_TIMEOUT))
+    while (( SECONDS < deadline )); do
+      if invoke_cluster_cli get crd backstages.rhdh.redhat.com &>/dev/null; then
+        break
+      fi
+      sleep 5
+    done
+    if ! invoke_cluster_cli get crd backstages.rhdh.redhat.com &>/dev/null; then
+      errorf "CRD backstages.rhdh.redhat.com was not created within ${OLM_V1_WAIT_TIMEOUT}s"
+      dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}" \
+        "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}"
+      exit 1
+    fi
+  fi
 
   # Post-install output
   CLUSTER_ROUTER_BASE=$(invoke_cluster_cli get ingress.config.openshift.io/cluster '-o=jsonpath={.spec.domain}' 2>/dev/null || true)
 
   echo "
-Done. ClusterExtension '${OPERATOR_NAME_TO_INSTALL}' created via OLM v1.
+Done. ClusterExtension '${OPERATOR_NAME_TO_INSTALL}' is Installed via OLM v1.
 
 To create an RHDH instance:
 ${CR_EXAMPLE}

--- a/.rhdh/scripts/install-rhdh-catalog-source.sh
+++ b/.rhdh/scripts/install-rhdh-catalog-source.sh
@@ -244,6 +244,11 @@ function prepare_olm_v1_secrets() {
     -o jsonpath='{.items[0].spec.template.spec.serviceAccountName}' 2>/dev/null || true)
   controller_sa="${controller_sa:-operator-controller-controller-manager}"
 
+  # Image project for the rebuilt IIB (created by ocp_install); ensure it exists before grants.
+  if ! oc get namespace "${image_namespace}" &>/dev/null; then
+    oc create namespace "${image_namespace}" >&2
+  fi
+
   debugf "Granting image-puller in namespace '${image_namespace}' to OLM v1 service accounts"
   if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${catalogd_ns}:${catalogd_sa}" -n "${image_namespace}" || \
      ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${controller_ns}:${controller_sa}" -n "${image_namespace}"; then
@@ -1104,7 +1109,16 @@ if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
   fi
   debugf "Using operator-controller namespace: ${NAMESPACE_OLM_CONTROLLER}"
 
-  if ! prepare_olm_v1_secrets "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}" "rhdh"; then
+  # OpenShift IIB is rebuilt into the internal registry under <project>/iib:...
+  # (ocp_install uses "rhdh"). Derive the project from the image ref instead of
+  # assuming the RHDH app deploy namespace (e.g. showcase).
+  IMAGE_NAMESPACE="rhdh"
+  if [[ "${newIIBImage}" =~ ^image-registry\.openshift-image-registry\.svc:5000/([^/]+)/ ]]; then
+    IMAGE_NAMESPACE="${BASH_REMATCH[1]}"
+  fi
+  debugf "Using image namespace for OLM v1 puller grants: ${IMAGE_NAMESPACE}"
+
+  if ! prepare_olm_v1_secrets "${NAMESPACE_CATALOGD}" "${NAMESPACE_OLM_CONTROLLER}" "${IMAGE_NAMESPACE}"; then
     dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}"
     exit 1
   fi
@@ -1173,8 +1187,8 @@ subjects:
 " > "$TMPDIR"/ClusterRoleBinding.yml && invoke_cluster_cli apply -f "$TMPDIR"/ClusterRoleBinding.yml
 
   if [[ "${IS_OPENSHIFT}" = "true" ]]; then
-    if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_SUBSCRIPTION}:${SA_NAME}" -n rhdh; then
-      errorf "Failed to grant image-puller to installer SA '${SA_NAME}' in namespace rhdh"
+    if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAMESPACE_SUBSCRIPTION}:${SA_NAME}" -n "${IMAGE_NAMESPACE}"; then
+      errorf "Failed to grant image-puller to installer SA '${SA_NAME}' in namespace ${IMAGE_NAMESPACE}"
       dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}"
       exit 1
     fi
@@ -1211,18 +1225,11 @@ spec:
     exit 1
   fi
 
-  # When installing RHDH, also wait for the Backstage CRD before reporting success.
+  # When installing RHDH, wait until the Backstage CRD is Established (not merely present).
   if [[ "${OPERATOR_NAME_IN_CS}" == "rhdh" || "${OPERATOR_NAME_TO_INSTALL}" == "rhdh" ]]; then
-    infof "Waiting for CRD backstages.rhdh.redhat.com (timeout 300s)..."
-    deadline=$((SECONDS + 300))
-    while (( SECONDS < deadline )); do
-      if invoke_cluster_cli get crd backstages.rhdh.redhat.com &>/dev/null; then
-        break
-      fi
-      sleep 5
-    done
-    if ! invoke_cluster_cli get crd backstages.rhdh.redhat.com &>/dev/null; then
-      errorf "CRD backstages.rhdh.redhat.com was not created within 300s"
+    infof "Waiting for CRD backstages.rhdh.redhat.com Established (timeout 300s)..."
+    if ! invoke_cluster_cli wait --for=condition=Established crd/backstages.rhdh.redhat.com --timeout=300s; then
+      errorf "CRD backstages.rhdh.redhat.com was not Established within 300s"
       dump_olm_v1_diagnostics "${CATALOGSOURCE_NAME}" "${OPERATOR_NAME_TO_INSTALL}"
       exit 1
     fi


### PR DESCRIPTION
## Description

Fixes the OLM v1 path in `install-rhdh-catalog-source.sh` so RHDH operator install does not exit 0 before the operator is actually ready (the failure mode in OCP 4.18 operator nightlies after #3047).

`--olm-version auto` still prefers v1 when the ClusterExtension CRD is present (OpenShift and Kubernetes).

### Changes

- Align ClusterCatalog/ClusterExtension manifests with working samples (catalog selector label + `crdUpgradeSafety: None`)
- Wait for ClusterCatalog `Serving`, ClusterExtension `Installed`, and (for RHDH) CRD `backstages.rhdh.redhat.com` **Established** before printing Done; on timeout dump slim diagnostics and exit non-zero
- On OpenShift, merge internal (and optional external) registry credentials into `openshift-config/pull-secret` so catalogd can pull the rebuilt IIB (`authentication required` without this)
- Derive `IMAGE_NAMESPACE` from the rebuilt IIB image ref for image-puller grants (IIB project, not the app deploy ns); ensure that namespace exists before grants
- Resolve OLM controller SAs for image-puller grants and fail hard if grants fail on OpenShift
- Hardcoded 300s wait timeouts; external registry default-route is optional (warn + continue)
- Document OLM auto-detect and the Serving / Installed / Established readiness gates

### Verification

Live path matrix on workshop OCP 4.20 (auto v1 install, explicit v1, v1 catalog-only, v0 install, v0 catalog-only) — all exited 0 with expected resources.

## Which issue(s) does this PR fix or relate to

- Fixes [RHDHBUGS-3510](https://issues.redhat.com/browse/RHDHBUGS-3510)
- Relates to #3047 (OLM v1 auto-detect); failure example: [e2e-ocp-operator-nightly #2081968295161892864](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-developer-rhdh-main-e2e-ocp-operator-nightly/2081968295161892864)

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer

On an OCP 4.18+ cluster where the ClusterExtension CRD exists:

```bash
bash .rhdh/scripts/install-rhdh-catalog-source.sh --next --install-operator rhdh
oc get crd backstages.rhdh.redhat.com
oc get clustercatalog rhdh-fast -o jsonpath='{.status.conditions[?(@.type=="Serving")].status}{"\n"}'
oc get clusterextension rhdh -o jsonpath='{.status.conditions[?(@.type=="Installed")].status}{"\n"}'

# Explicit v0 still works
bash .rhdh/scripts/install-rhdh-catalog-source.sh --next --install-operator rhdh --olm-version v0
```

Expect either a real install (CRD Established + operator pod Running) or a non-zero exit with OLM v1 diagnostics — never silent success.

## Building Container Images for Testing

N/A (script/docs only).

Made with [Cursor](https://cursor.com)