### PR TITLE
chore: move upstream rhdh-operator to...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,17 +26,15 @@ DEFAULT_VERSION := false
 endif
 
 # IMAGE_TAG_VERSION is the image tag, which might be different from VERSION.
-# For example, the RHDH profile uses 1.y as image tags if VERSION is 1.y.z
+# For example, the RHDH profile uses x.y as image tags if VERSION is x.y.z
 IMAGE_TAG_VERSION = $(VERSION)
 
 ifeq ($(PROFILE), rhdh)
 	# Profile-specific settings
 	ifeq ($(DEFAULT_VERSION), true)
-		# transforming: 0.y.z => 1.y.z. Only if VERSION was not explicitly overridden by the user
-		MAJOR := $(shell echo $(VERSION) | cut -d. -f1)
-		INCREMENTED_MAJOR := $(shell expr $(MAJOR) + 1)
-		MINOR_PATCH := $(shell echo $(VERSION) | cut -d. -f2-)
-		VERSION := $(INCREMENTED_MAJOR).$(MINOR_PATCH)
+		# Keep the same major version as VERSION (community and RHDH are aligned).
+		# Strip the patch for IMAGE_TAG_VERSION (x.y.z => x.y) to match downstream
+		# quay.io/rhdh image tags. Only if VERSION was not explicitly overridden.
 		IMAGE_TAG_VERSION := $(shell echo $(VERSION) | cut -d. -f1,2)
 	endif
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PROFILE_SHORT := $(shell echo $(PROFILE) | cut -d. -f1)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 # Set a default VERSION if it is not defined
 ifeq ($(origin VERSION), undefined)
-VERSION ?= 0.11.0
+VERSION ?= 2.0.0
 DEFAULT_VERSION := true
 else
 DEFAULT_VERSION := false

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ ifeq ($(PROFILE), rhdh)
 		IMAGE_TAG_VERSION := $(shell echo $(VERSION) | cut -d. -f1,2)
 	endif
 
-	# Downstream: IMAGE_TAG_BASE ?= quay.io/rhdh/rhdh-rhel9-operator or registry.redhat.io/rhdh/rhdh-rhel9-operator
-	IMAGE_TAG_BASE ?= quay.io/rhdh-community/operator
+	# IMAGE_TAG_BASE ?= registry.redhat.io/rhdh/rhdh-rhel9-operator
+	IMAGE_TAG_BASE ?= quay.io/rhdh/rhdh-rhel9-operator
 	DEFAULT_CHANNEL ?= fast
 	CHANNELS ?= fast,fast-\$${CI_X_VERSION}.\$${CI_Y_VERSION}
 	BUNDLE_METADATA_PACKAGE_NAME ?= rhdh

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ ifeq ($(PROFILE), rhdh)
 		IMAGE_TAG_VERSION := $(shell echo $(VERSION) | cut -d. -f1,2)
 	endif
 
-	# IMAGE_TAG_BASE ?= registry.redhat.io/rhdh/rhdh-rhel9-operator
-	IMAGE_TAG_BASE ?= quay.io/rhdh/rhdh-rhel9-operator
+	# Downstream: IMAGE_TAG_BASE ?= quay.io/rhdh/rhdh-rhel9-operator or registry.redhat.io/rhdh/rhdh-rhel9-operator
+	IMAGE_TAG_BASE ?= quay.io/rhdh-community/operator
 	DEFAULT_CHANNEL ?= fast
 	CHANNELS ?= fast,fast-\$${CI_X_VERSION}.\$${CI_Y_VERSION}
 	BUNDLE_METADATA_PACKAGE_NAME ?= rhdh

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
           }
         }
       ]
-    createdAt: "2026-07-17T09:46:42Z"
+    createdAt: "2026-07-27T14:17:21Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   labels:
     operatorframework.io/arch.amd64: supported
-  name: backstage-operator.v0.11.0
+  name: backstage-operator.v2.0.0
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -215,7 +215,7 @@ spec:
                 - --metrics-bind-address=:8443
                 command:
                 - /manager
-                image: quay.io/rhdh-community/operator:0.11.0
+                image: quay.io/rhdh-community/operator:2.0.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -326,4 +326,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
-  version: 0.11.0
+  version: 2.0.0

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools
     certified: "true"
-    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.11
+    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:2.0
     createdAt: "2026-07-17T09:46:46Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
@@ -49,12 +49,12 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
-    skipRange: '>=1.0.0 <1.11.0'
+    skipRange: '>=1.0.0 <2.0.0'
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: rhdh-operator.v1.11.0
+  name: rhdh-operator.v2.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -318,7 +318,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/rhdh-community/rhdh:next
-                image: quay.io/rhdh/rhdh-rhel9-operator:1.11
+                image: quay.io/rhdh/rhdh-rhel9-operator:2.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -450,4 +450,4 @@ spec:
   - image: quay.io/rhdh-community/rhdh:next
     name: backstage
   replaces: rhdh-operator.v1.10.0
-  version: 1.11.0
+  version: 2.0.0

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:2.0
-    createdAt: "2026-07-17T09:46:46Z"
+    createdAt: "2026-07-27T14:17:23Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/config/manifests/rhdh/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/rhdh/bases/backstage-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools
     certified: "true"
-    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.11
+    containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:2.0
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed
@@ -23,7 +23,7 @@ metadata:
     operatorframework.io/suggested-namespace: rhdh-operator
     operators.openshift.io/valid-subscription: '["Red Hat Developer Hub"]'
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
-    skipRange: '>=1.0.0 <1.11.0'
+    skipRange: '>=1.0.0 <2.0.0'
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
@@ -117,4 +117,4 @@ spec:
     name: Red Hat Inc.
     url: https://www.redhat.com/
   replaces: rhdh-operator.v1.10.0
-  version: 1.11.0
+  version: 2.0.0

--- a/config/profile/backstage.io/kustomization.yaml
+++ b/config/profile/backstage.io/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.11.0
+  newTag: 2.0.0
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/profile/rhdh/kustomization.yaml
+++ b/config/profile/rhdh/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 images:
 - name: controller
   newName: quay.io/rhdh/rhdh-rhel9-operator
-  newTag: "1.11"
+  newTag: "2.0"
 
 patches:
 - path: patches/deployment-patch.yaml

--- a/dist/backstage.io/install.yaml
+++ b/dist/backstage.io/install.yaml
@@ -2796,7 +2796,7 @@ spec:
         - --metrics-bind-address=:8443
         command:
         - /manager
-        image: quay.io/rhdh-community/operator:0.11.0
+        image: quay.io/rhdh-community/operator:2.0.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -4042,7 +4042,7 @@ spec:
           value: quay.io/fedora/postgresql-15:latest
         - name: RELATED_IMAGE_backstage
           value: quay.io/rhdh-community/rhdh:next
-        image: quay.io/rhdh/rhdh-rhel9-operator:1.11
+        image: quay.io/rhdh/rhdh-rhel9-operator:2.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/dynamic-plugins.md
+++ b/docs/dynamic-plugins.md
@@ -128,7 +128,7 @@ plugins:
   - package: "oci://any-registry/path/backstage-plugin-catalog:{{inherit}}"
 ```
 
-**Since v0.11.0:** Both `ref://` and `:{{inherit}}` use name-based matching (plugin name only, registry/path ignored). This behavior is slightly different from what is described in [OCI Package Version Inheritance](https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/installing-plugins.md#oci-package-version-inheritance) which documents the RHDH init-container behavior (full URL matching).
+**Since v2.0.0:** Both `ref://` and `:{{inherit}}` use name-based matching (plugin name only, registry/path ignored). This behavior is slightly different from what is described in [OCI Package Version Inheritance](https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/installing-plugins.md#oci-package-version-inheritance) which documents the RHDH init-container behavior (full URL matching).
 
 ## Dynamic plugins dependency management
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -47,9 +47,9 @@ As of January 2025, there are three predefined profiles:
 
 For reference, this profile performs the following specific customizations:
 
-* Incrementing the minor element in the version, i.e., from `x.y.z` to `(x+1).y.z`. For example, if the default version in the Makefile is 0.1.2, the RHDH version would actually set it to 1.1.2. This is done so to align with the Red Hat Developer Hub versioning.
+* Keeping the same major version as the Makefile `VERSION` so the community and RHDH operators stay aligned (for example, `2.0.0` remains `2.0.0`)
 * Switching the default image base from [`quay.io/rhdh-community/operator`](https://quay.io/rhdh-community/operator) to [`quay.io/rhdh/rhdh-rhel9-operator`](https://quay.io/rhdh/rhdh-rhel9-operator)
-* Removing the patch element from the version semver, i.e., from `x.y.z` to `x.y`, because that's how the downstream images on [`quay.io/rhdh`] are being tagged
+* Removing the patch element from the image tag, i.e., from `x.y.z` to `x.y`, because that's how the downstream images on [`quay.io/rhdh`] are being tagged
 * Changing the bundle channels from `alpha` to `fast` and `fast-${CI_X_VERSION}.${CI_Y_VERSION}` (which will be ultimately replaced in the final downstream pipelines)
 * Changing the package name into `rhdh`
 * When generating the bundle manifests by running either `make bundle [PROFILE=rhdh]` or `make bundles`, the resulting [`ClusterServiceVersion`](https://sdk.operatorframework.io/docs/olm-integration/generation/#clusterserviceversion-manifests) is renamed into `rhdh-operator`


### PR DESCRIPTION
### What does this PR do?

chore: move upstream rhdh-operator to version 2.0 so it aligns with downstream version

Signed-off-by: rhdh-bot <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.