### PR TITLE
chore(ci): add cosign signing to community image builds

### DIFF
--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -86,7 +86,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     env:
+      HAS_QUAY_AUTH: ${{ vars.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
       SHORT_SHA: ${{ needs.changes.outputs.short_sha }}
       BASE_VERSION: ${{ needs.changes.outputs.base_version }}
       LATEST_NEXT: ${{ needs.changes.outputs.latest_next }}
@@ -107,6 +109,10 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ vars.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Install cosign
+        if: env.HAS_QUAY_AUTH == 'true'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Build and push operator-bundle
         run: |
@@ -132,6 +138,26 @@ jobs:
           REGISTRY_ORG: ${{ vars.REGISTRY_ORG }}
           OPERATOR_IMAGE_NAME: ${{ vars.OPERATOR_IMAGE_NAME || 'operator' }}
           GH_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
+
+      - name: Sign the published bundle image
+        if: env.HAS_QUAY_AUTH == 'true'
+        run: |
+          set -euo pipefail
+          export REGISTRY_WITH_ORG="${REGISTRY}/${REGISTRY_ORG}"
+
+          for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do
+            FULL_REF="${REGISTRY_WITH_ORG}/${OPERATOR_IMAGE_NAME}-bundle:${tag}"
+            DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${FULL_REF}")
+            if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+              echo "::error::Could not resolve digest for ${FULL_REF}"
+              exit 1
+            fi
+            echo "Signing ${FULL_REF}@${DIGEST}"
+            cosign sign --yes "${FULL_REF}@${DIGEST}"
+          done
+        env:
+          REGISTRY_ORG: ${{ vars.REGISTRY_ORG }}
+          OPERATOR_IMAGE_NAME: ${{ vars.OPERATOR_IMAGE_NAME || 'operator' }}
 
   build:
     name: Build (${{ matrix.os }})
@@ -262,6 +288,7 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Install cosign
+        if: env.HAS_QUAY_AUTH == 'true'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Create manifest lists and push

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -245,6 +245,7 @@ jobs:
       packages: write
       id-token: write
     env:
+      HAS_QUAY_AUTH: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
       HAS_QUAY_OAUTH: ${{ secrets.QUAY_OAUTH_TOKEN != '' }}
       SHORT_SHA: ${{ needs.changes.outputs.short_sha }}
       BASE_VERSION: ${{ needs.changes.outputs.base_version }}
@@ -305,12 +306,18 @@ jobs:
           OPERATOR_IMAGE_NAME: ${{ vars.OPERATOR_IMAGE_NAME || 'operator' }}
 
       - name: Sign the published images
+        if: env.HAS_QUAY_AUTH == 'true'
         run: |
           set -euo pipefail
           export REGISTRY_WITH_ORG="${REGISTRY}/${REGISTRY_ORG}"
 
           for image in "${OPERATOR_IMAGE_NAME}" "${OPERATOR_IMAGE_NAME}-catalog"; do
-            DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${REGISTRY_WITH_ORG}/${image}:${LATEST_NEXT}" | jq -r '.digest')
+            DIGEST=$(docker buildx imagetools inspect "${REGISTRY_WITH_ORG}/${image}:${LATEST_NEXT}" --format '{{println .Digest}}')
+
+            if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+              echo "::warning::Could not resolve digest for ${REGISTRY_WITH_ORG}/${image}:${LATEST_NEXT}, skipping signing"
+              continue
+            fi
 
             for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do
               echo "Signing ${REGISTRY_WITH_ORG}/${image}:${tag}@${DIGEST}"

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -314,7 +314,7 @@ jobs:
           for image in "${OPERATOR_IMAGE_NAME}" "${OPERATOR_IMAGE_NAME}-catalog"; do
             for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do
               FULL_REF="${REGISTRY_WITH_ORG}/${image}:${tag}"
-              DIGEST=$(docker buildx imagetools inspect "$FULL_REF" --format '{{println .Digest}}')
+              DIGEST=$(docker buildx imagetools inspect "$FULL_REF" | grep '^Digest:' | awk '{print $2}')
               if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
                 echo "::error::Could not resolve digest for ${FULL_REF}"
                 exit 1

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -311,13 +311,6 @@ jobs:
           set -euo pipefail
           export REGISTRY_WITH_ORG="${REGISTRY}/${REGISTRY_ORG}"
 
-          : "${REGISTRY:?REGISTRY must be set}"
-          : "${REGISTRY_ORG:?REGISTRY_ORG must be set}"
-          : "${OPERATOR_IMAGE_NAME:?OPERATOR_IMAGE_NAME must be set}"
-          : "${BASE_VERSION:?BASE_VERSION must be set}"
-          : "${SHORT_SHA:?SHORT_SHA must be set}"
-          : "${LATEST_NEXT:?LATEST_NEXT must be set}"
-
           for image in "${OPERATOR_IMAGE_NAME}" "${OPERATOR_IMAGE_NAME}-catalog"; do
             for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do
               FULL_REF="${REGISTRY_WITH_ORG}/${image}:${tag}"

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -243,6 +243,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     env:
       HAS_QUAY_OAUTH: ${{ secrets.QUAY_OAUTH_TOKEN != '' }}
       SHORT_SHA: ${{ needs.changes.outputs.short_sha }}
@@ -258,6 +259,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Create manifest lists and push
         run: |
@@ -295,6 +299,23 @@ jobs:
 
             echo "=== Inspecting manifest for ${image}:${LATEST_NEXT} ==="
             docker buildx imagetools inspect "${REGISTRY_WITH_ORG}/${image}:${LATEST_NEXT}"
+          done
+        env:
+          REGISTRY_ORG: ${{ vars.REGISTRY_ORG }}
+          OPERATOR_IMAGE_NAME: ${{ vars.OPERATOR_IMAGE_NAME || 'operator' }}
+
+      - name: Sign the published images
+        run: |
+          set -euo pipefail
+          export REGISTRY_WITH_ORG="${REGISTRY}/${REGISTRY_ORG}"
+
+          for image in "${OPERATOR_IMAGE_NAME}" "${OPERATOR_IMAGE_NAME}-catalog"; do
+            DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' "${REGISTRY_WITH_ORG}/${image}:${LATEST_NEXT}" | jq -r '.digest')
+
+            for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do
+              echo "Signing ${REGISTRY_WITH_ORG}/${image}:${tag}@${DIGEST}"
+              cosign sign --yes "${REGISTRY_WITH_ORG}/${image}:${tag}@${DIGEST}"
+            done
           done
         env:
           REGISTRY_ORG: ${{ vars.REGISTRY_ORG }}

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -245,7 +245,7 @@ jobs:
       packages: write
       id-token: write
     env:
-      HAS_QUAY_AUTH: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
+      HAS_QUAY_AUTH: ${{ vars.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
       HAS_QUAY_OAUTH: ${{ secrets.QUAY_OAUTH_TOKEN != '' }}
       SHORT_SHA: ${{ needs.changes.outputs.short_sha }}
       BASE_VERSION: ${{ needs.changes.outputs.base_version }}
@@ -310,6 +310,13 @@ jobs:
         run: |
           set -euo pipefail
           export REGISTRY_WITH_ORG="${REGISTRY}/${REGISTRY_ORG}"
+
+          : "${REGISTRY:?REGISTRY must be set}"
+          : "${REGISTRY_ORG:?REGISTRY_ORG must be set}"
+          : "${OPERATOR_IMAGE_NAME:?OPERATOR_IMAGE_NAME must be set}"
+          : "${BASE_VERSION:?BASE_VERSION must be set}"
+          : "${SHORT_SHA:?SHORT_SHA must be set}"
+          : "${LATEST_NEXT:?LATEST_NEXT must be set}"
 
           for image in "${OPERATOR_IMAGE_NAME}" "${OPERATOR_IMAGE_NAME}-catalog"; do
             for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -312,16 +312,15 @@ jobs:
           export REGISTRY_WITH_ORG="${REGISTRY}/${REGISTRY_ORG}"
 
           for image in "${OPERATOR_IMAGE_NAME}" "${OPERATOR_IMAGE_NAME}-catalog"; do
-            DIGEST=$(docker buildx imagetools inspect "${REGISTRY_WITH_ORG}/${image}:${LATEST_NEXT}" --format '{{println .Digest}}')
-
-            if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
-              echo "::warning::Could not resolve digest for ${REGISTRY_WITH_ORG}/${image}:${LATEST_NEXT}, skipping signing"
-              continue
-            fi
-
             for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do
-              echo "Signing ${REGISTRY_WITH_ORG}/${image}:${tag}@${DIGEST}"
-              cosign sign --yes "${REGISTRY_WITH_ORG}/${image}:${tag}@${DIGEST}"
+              FULL_REF="${REGISTRY_WITH_ORG}/${image}:${tag}"
+              DIGEST=$(docker buildx imagetools inspect "$FULL_REF" --format '{{println .Digest}}')
+              if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+                echo "::error::Could not resolve digest for ${FULL_REF}"
+                exit 1
+              fi
+              echo "Signing ${FULL_REF}@${DIGEST}"
+              cosign sign --yes "${FULL_REF}@${DIGEST}"
             done
           done
         env:

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -86,9 +86,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
     env:
-      HAS_QUAY_AUTH: ${{ vars.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
       SHORT_SHA: ${{ needs.changes.outputs.short_sha }}
       BASE_VERSION: ${{ needs.changes.outputs.base_version }}
       LATEST_NEXT: ${{ needs.changes.outputs.latest_next }}
@@ -109,10 +107,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ vars.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Install cosign
-        if: env.HAS_QUAY_AUTH == 'true'
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Build and push operator-bundle
         run: |
@@ -138,26 +132,6 @@ jobs:
           REGISTRY_ORG: ${{ vars.REGISTRY_ORG }}
           OPERATOR_IMAGE_NAME: ${{ vars.OPERATOR_IMAGE_NAME || 'operator' }}
           GH_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
-
-      - name: Sign the published bundle image
-        if: env.HAS_QUAY_AUTH == 'true'
-        run: |
-          set -euo pipefail
-          export REGISTRY_WITH_ORG="${REGISTRY}/${REGISTRY_ORG}"
-
-          for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do
-            FULL_REF="${REGISTRY_WITH_ORG}/${OPERATOR_IMAGE_NAME}-bundle:${tag}"
-            DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${FULL_REF}")
-            if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
-              echo "::error::Could not resolve digest for ${FULL_REF}"
-              exit 1
-            fi
-            echo "Signing ${FULL_REF}@${DIGEST}"
-            cosign sign --yes "${FULL_REF}@${DIGEST}"
-          done
-        env:
-          REGISTRY_ORG: ${{ vars.REGISTRY_ORG }}
-          OPERATOR_IMAGE_NAME: ${{ vars.OPERATOR_IMAGE_NAME || 'operator' }}
 
   build:
     name: Build (${{ matrix.os }})
@@ -338,7 +312,7 @@ jobs:
           set -euo pipefail
           export REGISTRY_WITH_ORG="${REGISTRY}/${REGISTRY_ORG}"
 
-          for image in "${OPERATOR_IMAGE_NAME}" "${OPERATOR_IMAGE_NAME}-catalog"; do
+          for image in "${OPERATOR_IMAGE_NAME}" "${OPERATOR_IMAGE_NAME}-bundle" "${OPERATOR_IMAGE_NAME}-catalog"; do
             for tag in "${BASE_VERSION}" "${BASE_VERSION}-${SHORT_SHA}" "${LATEST_NEXT}"; do
               FULL_REF="${REGISTRY_WITH_ORG}/${image}:${tag}"
               DIGEST=$(docker buildx imagetools inspect "$FULL_REF" | grep '^Digest:' | awk '{print $2}')


### PR DESCRIPTION
- Add keyless cosign signing to the multi-arch `merge` job in `next-container-build.yaml`
- Community images at `quay.io/rhdh-community/operator` and `operator-catalog` will be signed after the multi-arch manifest is created
- Consumers can verify image provenance with `cosign verify` using the GitHub Actions OIDC issuer

Resolves: https://redhat.atlassian.net/browse/RHDHBUGS-3542

How to test: https://redhat.atlassian.net/browse/RHDHBUGS-3542?focusedCommentId=17811110

Signed-off-by: Fortune Ndlovu <fndlovu@redhat.com>