### PR TITLE
chore: tagRelease.sh: bump to 1.9.9 in release-1.9 branch [skip-build] [skip-e2e]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PROFILE_SHORT := $(shell echo $(PROFILE) | cut -d. -f1)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 # Set a default VERSION if it is not defined
 ifeq ($(origin VERSION), undefined)
-VERSION ?= 0.9.8
+VERSION ?= 0.9.9
 DEFAULT_VERSION := true
 else
 DEFAULT_VERSION := false

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -35,13 +35,13 @@ metadata:
           }
         }
       ]
-    createdAt: "2026-07-20T16:24:18Z"
+    createdAt: "2026-08-10T15:09:48Z"
     description: Backstage Operator
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   labels:
     operatorframework.io/arch.amd64: supported
-  name: backstage-operator.v0.9.8
+  name: backstage-operator.v0.9.9
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -235,7 +235,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/rhdh-community/operator:0.9.8
+                image: quay.io/rhdh-community/operator:0.9.9
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/backstage.io/manifests/backstage-operator.clusterserviceversion.yaml
@@ -346,4 +346,4 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
-  version: 0.9.8
+  version: 0.9.9

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.9
-    createdAt: "2026-07-20T16:24:20Z"
+    createdAt: "2026-08-10T15:09:49Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -59,12 +59,12 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
-    skipRange: '>=1.0.0 <1.9.8'
+    skipRange: '>=1.0.0 <1.9.9'
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: rhdh-operator.v1.9.8
+  name: rhdh-operator.v1.9.9
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -464,4 +464,4 @@ spec:
   - image: quay.io/rhdh/plugin-catalog-index:1.9
     name: catalog-index
   replaces: rhdh-operator.v1.9.0
-  version: 1.9.8
+  version: 1.9.9

--- a/config/manifests/rhdh/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/rhdh/bases/backstage-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     operatorframework.io/suggested-namespace: rhdh-operator
     operators.openshift.io/valid-subscription: '["Red Hat Developer Hub"]'
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
-    skipRange: '>=1.0.0 <1.9.8'
+    skipRange: '>=1.0.0 <1.9.9'
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
@@ -117,4 +117,4 @@ spec:
     name: Red Hat Inc.
     url: https://www.redhat.com/
   replaces: rhdh-operator.v1.9.0
-  version: 1.9.8
+  version: 1.9.9

--- a/config/profile/backstage.io/kustomization.yaml
+++ b/config/profile/backstage.io/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 images:
 - name: controller
   newName: quay.io/rhdh-community/operator
-  newTag: 0.9.8
+  newTag: 0.9.9
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/dist/backstage.io/install.yaml
+++ b/dist/backstage.io/install.yaml
@@ -2763,7 +2763,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: quay.io/rhdh-community/operator:0.9.8
+        image: quay.io/rhdh-community/operator:0.9.9
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
