### PR TITLE
[Release-1.10] chore: update lcore image from 0.5.3 to 0.6.2

### DIFF
--- a/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/rhdh/manifests/backstage-operator.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
     categories: Developer Tools
     certified: "true"
     containerImage: registry.redhat.io/rhdh/rhdh-rhel9-operator:1.10
-    createdAt: "2026-08-03T15:00:36Z"
+    createdAt: "2026-08-14T19:20:58Z"
     description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of
       an external database, and can help streamline the process of setting up a self-managed

--- a/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
+++ b/bundle/rhdh/manifests/rhdh-flavour-lightspeed-config_v1_configmap.yaml
@@ -285,7 +285,7 @@ data:
           containers:
             # Lightspeed Core Backend
             - name: lightspeed-core
-              image: quay.io/lightspeed-core/lightspeed-stack:0.5.3
+              image: quay.io/lightspeed-core/lightspeed-stack:0.6.2
               imagePullPolicy: Always
               ports:
                 - containerPort: 8080

--- a/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
+++ b/config/profile/rhdh/default-config/flavours/lightspeed/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         # Lightspeed Core Backend
         - name: lightspeed-core
-          image: quay.io/lightspeed-core/lightspeed-stack:0.5.3
+          image: quay.io/lightspeed-core/lightspeed-stack:0.6.2
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/dist/rhdh/install.yaml
+++ b/dist/rhdh/install.yaml
@@ -3307,7 +3307,7 @@ data:
           containers:
             # Lightspeed Core Backend
             - name: lightspeed-core
-              image: quay.io/lightspeed-core/lightspeed-stack:0.5.3
+              image: quay.io/lightspeed-core/lightspeed-stack:0.6.2
               imagePullPolicy: Always
               ports:
                 - containerPort: 8080


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
- Bumps LCORE image from 0.5.3 to 0.6.2 for RHDH 1.10.4 release as 0.5.x is going EOL


## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHIDP-16122

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Building Container Images for Testing

Need to test container images from this PR?

**For Maintainers:** To trigger a test image build, review the code and comment `/build-images`.
This always builds the HEAD of the PR branch.

**For Contributors:** Ask a maintainer to run `/build-images`.

Images will be built and pushed to Quay with links posted in comments.
