### PR TITLE
chore: exclude Dockerfiles from SonarCloud to silence docker:S8431

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -5,8 +5,13 @@ sonar.tests= .
 # Include test subdirectories in test scope
 sonar.test.inclusions = tests/**/*, integration_tests/**/*, **/*_test.go, **/testdata/**/*
 
-# Exclude test subdirectories from source scope
-sonar.exclusions = tests/**/*, integration_tests/**/*, **/*_test.go, **/zz_generated.deepcopy.go, **/testdata/**/*
+# Exclude test subdirectories from source scope.
+# Also drop the operator Dockerfiles: docker:S8431 flags FROM image:tag@sha256:...
+# which is the pinDigest form Konflux and "Validate Image Digests" require.
+# Dockerfile parsers reject NOSONAR, and sonar.issue.ignore.multicriteria is
+# ignored by SonarCloud Automatic Analysis (redhat-developer/rhdh#4967).
+# sonar.exclusions is honoured. Hadolint still lints these files.
+sonar.exclusions = tests/**/*, integration_tests/**/*, **/*_test.go, **/zz_generated.deepcopy.go, **/testdata/**/*, Dockerfile, .rhdh/docker/Dockerfile
 
 # Exclude api from duplication metric
 sonar.cpd.exclusions=api/**


### PR DESCRIPTION
## Summary
- Cherry-pick of https://github.com/redhat-developer/rhdh-operator/pull/3403 onto `release-1.10`.
- SonarCloud Automatic Analysis rule `docker:S8431` flags `FROM image:tag@sha256:...`, which is the pinDigest form Konflux and **Validate Image Digests** require. That is what failed the quality gate on https://github.com/redhat-developer/rhdh-operator/pull/3400.
- `sonar.issue.ignore.multicriteria` is not honoured by Automatic Analysis. Exclude `Dockerfile` and `.rhdh/docker/Dockerfile` instead. Hadolint still lints those files.

## Test plan
- [ ] SonarCloud Code Analysis on this PR does not report `docker:S8431`
- [ ] After merge, rebase https://github.com/redhat-developer/rhdh-operator/pull/3400 so it picks up `.sonarcloud.properties` from `release-1.10`

Generated-by: cursor

Ref: https://redhat.atlassian.net/browse/RHIDP-16179
