### PR TITLE
fix: move hermeto cache out of working tree (RHDHBUGS-3688)

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -64,13 +64,13 @@ runs:
       run: |
         # renovate: datasource=docker depName=quay.io/konflux-ci/hermeto
         echo "HERMETO_IMAGE=quay.io/konflux-ci/hermeto:0.60.1" >> "$GITHUB_ENV"
-        echo "LOCAL_CACHE_DIR=./hermeto-cache/operator" >> "$GITHUB_ENV"
+        echo "LOCAL_CACHE_DIR=/tmp/hermeto-cache/operator" >> "$GITHUB_ENV"
 
     - name: Restore hermeto dependency cache
       id: cache-deps
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ./hermeto-cache/operator
+        path: /tmp/hermeto-cache/operator
         key: hermeto-deps-${{ inputs.platform }}-${{ hashFiles('go.mod', 'go.sum', 'rpms.lock.yaml') }}
 
     - name: Fetch dependencies with hermeto

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -113,12 +113,18 @@ jobs:
 
           # Build bundle and catalog (operator was built hermetically above)
           make bundle bundle-build
+
+          # Push operator and bundle images before catalog-build — opm render
+          # needs to pull the bundle image from the registry
+          for image in ${OPERATOR_IMAGE_NAME} ${OPERATOR_IMAGE_NAME}-bundle; do
+            podman push -q ${REGISTRY_WITH_ORG}/${image}:${VERSION} docker://${REGISTRY_WITH_ORG}/${image}:${VERSION}
+          done
+
           BUNDLE_IMGS="${REGISTRY_WITH_ORG}/${OPERATOR_IMAGE_NAME}-bundle:${VERSION}" make -o bundle-push catalog-build
 
-          # Push all images
+          # Push catalog image and create PR-number tags for all images
+          podman push -q ${REGISTRY_WITH_ORG}/${OPERATOR_IMAGE_NAME}-catalog:${VERSION} docker://${REGISTRY_WITH_ORG}/${OPERATOR_IMAGE_NAME}-catalog:${VERSION}
           for image in ${OPERATOR_IMAGE_NAME} ${OPERATOR_IMAGE_NAME}-bundle ${OPERATOR_IMAGE_NAME}-catalog; do
-            podman push -q ${REGISTRY_WITH_ORG}/${image}:${VERSION} docker://${REGISTRY_WITH_ORG}/${image}:${VERSION}
-            skopeo --insecure-policy copy --all docker://${REGISTRY_WITH_ORG}/${image}:${VERSION} docker://${REGISTRY_WITH_ORG}/${image}:${VERSION}
             skopeo --insecure-policy copy --all docker://${REGISTRY_WITH_ORG}/${image}:${VERSION} docker://${REGISTRY_WITH_ORG}/${image}:${VERSION%-*}
           done
 


### PR DESCRIPTION
PR image builds have been failing because the hermeto dependency cache at `./hermeto-cache/operator` sits inside the working tree. When `make bundle` runs `controller-gen paths=./...`, it walks into the cache and hits `go.work` files left in cached Go module sources like `go-openapi/swag@v0.25.4`. These workspace files reference sibling modules that don't exist in the cache, so `controller-gen` errors out.

This PR moves the cache to `/tmp/hermeto-cache/operator` so it lives outside the working tree and `controller-gen` never scans it. It also fixes the image push ordering `catalog-build` calls `opm render` which pulls the bundle image from the registry, but the bundle wasn't being pushed until after `catalog-build` ran. The operator and bundle images are now pushed before `catalog-build` so `opm render` can find them.

Jira: https://redhat.atlassian.net/browse/RHDHBUGS-3688