### PR TITLE
chore: raise go.mod toolchain to go1.26.7 to match ubi9/go-toolset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/redhat-developer/rhdh-operator
 
 go 1.26.0
 
-toolchain go1.26.6
+toolchain go1.26.7
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1


### PR DESCRIPTION
## Summary
- `ubi9/go-toolset:9.8-1787774815` ships Go 1.26.7; raise `toolchain` from `go1.26.6` (do not lower `go 1.26.0`).

## Test plan
- [ ] `go version` in the toolset image is 1.26.7
- [ ] Operator build uses the local toolchain

Generated-by: cursor

Ref: https://redhat.atlassian.net/browse/RHIDP-16179
