### PR TITLE
feat(ci): auto-approve rhdh-bot chore/automated PRs

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -25,9 +25,10 @@ name: Auto-Approve Bot PRs
 # 10s after the last push.
 # labeled is omitted so adding lgtm/approved does not retrigger this workflow.
 #
-# github-actions[bot] applies labels and the review (not the PR author),
+# The RHDH GitHub App applies labels and the review (not the PR author),
 # because Prow rejects self-/lgtm from rhdh-bot. The GitHub approval
 # satisfies the 1-review branch protection; Tide merges on the lgtm label.
+# App secrets are required; there is no GITHUB_TOKEN fallback.
 
 on:
   pull_request_target:
@@ -50,6 +51,24 @@ jobs:
     if: github.event.pull_request.user.login == 'rhdh-bot'
 
     steps:
+      - name: Require RHDH GitHub App secrets
+        env:
+          APP_ID: ${{ secrets.RHDH_GITHUB_APP_ID }}
+          APP_KEY: ${{ secrets.RHDH_GITHUB_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -z "${APP_ID}" || -z "${APP_KEY}" ]]; then
+            echo "::error::RHDH_GITHUB_APP_ID and RHDH_GITHUB_APP_PRIVATE_KEY must be configured as repo secrets. There is no GITHUB_TOKEN fallback."
+            exit 1
+          fi
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.RHDH_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RHDH_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Check PR eligibility
         id: check-eligibility
         env:
@@ -84,7 +103,7 @@ jobs:
         id: debounce
         if: steps.check-eligibility.outputs.eligible == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -105,7 +124,7 @@ jobs:
       - name: Add required labels and approve PR
         if: steps.check-eligibility.outputs.eligible == 'true' && steps.debounce.outputs.stable == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr edit "$PR_NUMBER" --add-label "lgtm,approved" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -1,0 +1,120 @@
+# Copyright Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Auto-Approve Bot PRs
+
+# Adds lgtm/approved and a GitHub review so Prow Tide can squash-merge
+# rhdh-bot PRs (base-image bumps, RPM lockfile updates, and similar).
+#
+# pull_request_target runs this file from the *base* branch, so every
+# release-* line needs the same debounce. updateBaseImages.sh opens the PR
+# on the first image bump and pushes another commit seconds later; Prow
+# then strips lgtm. Wait 10s after the triggering commit and skip if HEAD
+# moved. A later synchronize run (with cancel-in-progress) applies lgtm
+# 10s after the last push.
+# labeled is omitted so adding lgtm/approved does not retrigger this workflow.
+#
+# github-actions[bot] applies labels and the review (not the PR author),
+# because Prow rejects self-/lgtm from rhdh-bot. The GitHub approval
+# satisfies the 1-review branch protection; Tide merges on the lgtm label.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: auto-approve-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-approve:
+    name: Auto-Approve and Label PRs
+    runs-on: ubuntu-latest
+
+    if: github.event.pull_request.user.login == 'rhdh-bot'
+
+    steps:
+      - name: Check PR eligibility
+        id: check-eligibility
+        env:
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          if [[ "$PR_DRAFT" == "true" ]]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "reason=PR is in draft state" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ELIGIBLE_PATTERNS=(
+            "^chore/automated-.*"
+          )
+
+          ELIGIBLE=false
+          for pattern in "${ELIGIBLE_PATTERNS[@]}"; do
+            if [[ "$PR_BRANCH" =~ $pattern ]]; then
+              ELIGIBLE=true
+              break
+            fi
+          done
+
+          if [[ "$ELIGIBLE" == "true" ]]; then
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait until HEAD is stable
+        id: debounce
+        if: steps.check-eligibility.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          DEBOUNCE_SECONDS=10
+          echo "Waiting ${DEBOUNCE_SECONDS}s after ${EVENT_SHA} so later commits can land and Prow can process synchronize."
+          sleep "${DEBOUNCE_SECONDS}"
+
+          CURRENT_SHA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)
+          if [[ "${CURRENT_SHA}" != "${EVENT_SHA}" ]]; then
+            echo "HEAD moved during debounce (${EVENT_SHA} -> ${CURRENT_SHA}); skipping so the newer run can label."
+            echo "stable=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "HEAD unchanged for ${DEBOUNCE_SECONDS}s: ${CURRENT_SHA}"
+          echo "stable=true" >> "$GITHUB_OUTPUT"
+
+      - name: Add required labels and approve PR
+        if: steps.check-eligibility.outputs.eligible == 'true' && steps.debounce.outputs.stable == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "lgtm,approved" --repo "$GITHUB_REPOSITORY"
+
+          gh pr review "$PR_NUMBER" \
+            --approve \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "**Auto-Approved**
+
+          This PR has been automatically approved by the auto-approve workflow.
+
+          **Labels Added:** \`lgtm\`, \`approved\`"

--- a/.github/workflows/update-rpm-lockfile.yaml
+++ b/.github/workflows/update-rpm-lockfile.yaml
@@ -29,6 +29,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Require RHDH_BOT_TOKEN
+        env:
+          RHDH_BOT_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
+        run: |
+          if [[ -z "${RHDH_BOT_TOKEN}" ]]; then
+            echo "::error::RHDH_BOT_TOKEN must be configured as a repo secret (rhdh-bot PAT). There is no GITHUB_TOKEN fallback."
+            exit 1
+          fi
+
       - name: Check if hermetic Dockerfile exists
         run: |
           if [ ! -f "${{ env.DOCKERFILE_PATH }}" ]; then


### PR DESCRIPTION
## Summary
- Cherry-pick of the main auto-approve workflow. `pull_request_target` runs from the base branch, so release-1.10 needs the same debounce.

## Test plan
- [ ] After merge, rhdh-bot `chore/automated-*` PRs targeting release-1.10 get `lgtm`/`approved` and a github-actions review.

Generated-by: cursor

Ref: https://redhat.atlassian.net/browse/RHIDP-16179
