### PR TITLE
chore(intelligent-assistant): change intelligent assistant (lightspeed) configs repository

### DIFF
--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -91,7 +91,7 @@ jobs:
             git push origin "${BRANCH}"
 
             BODY=$(cat <<EOF
-          Automated nightly sync of Lightspeed Core config files from [redhat-ai-dev/lightspeed-configs @ ${TARGET_BRANCH}](https://github.com/redhat-ai-dev/lightspeed-configs/tree/${TARGET_BRANCH}).
+          Automated nightly sync of Lightspeed Core config files from [redhat-developer/rhdh-intelligent-assistant-configs @ ${TARGET_BRANCH}](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs/tree/${TARGET_BRANCH}).
 
           ### Synced files
           - \`config/profile/rhdh/default-config/flavours/intelligent-assistant/configmap-files.yaml\`

--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -77,6 +77,11 @@ jobs:
         run: |
           TITLE="chore(lightspeed): sync config files from upstream"
           BRANCH="chore/sync-lightspeed-configs-${TARGET_BRANCH}"
+          TARGET_REPO="redhat-developer/rhdh-intelligent-assistant-configs"
+          
+          if [[ "${TARGET_BRANCH}" == "release-1.10" ]]; then
+            TARGET_REPO="redhat-ai-dev/lightspeed-configs"
+          fi
 
           EXISTING_PR=$(gh pr list --head "${BRANCH}" --base "${TARGET_BRANCH}" --state open --json number --jq '.[0].number // empty')
 
@@ -96,7 +101,7 @@ jobs:
             git push origin "${BRANCH}"
 
             BODY=$(cat <<EOF
-          Automated nightly sync of Lightspeed Core config files from [redhat-developer/rhdh-intelligent-assistant-configs @ ${TARGET_BRANCH}](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs/tree/${TARGET_BRANCH}).
+          Automated nightly sync of Lightspeed Core config files from [${TARGET_REPO} @ ${TARGET_BRANCH}](https://github.com/${TARGET_REPO}/tree/${TARGET_BRANCH}).
 
           ### Synced files
           - \`config/profile/rhdh/default-config/flavours/intelligent-assistant/configmap-files.yaml\`

--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -47,7 +47,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Sync Lightspeed Core config files
-        run: ./hack/sync-lightspeed-configs.sh --ref ${{ matrix.branch }}
+        run: |
+          if [[ "${{ matrix.branch }}" == "release-1.10" ]]; then
+            ./hack/sync-lightspeed-configs.sh --repo redhat-ai-dev/lightspeed-configs --ref ${{ matrix.branch }}
+          else
+            ./hack/sync-lightspeed-configs.sh --ref ${{ matrix.branch }}
+          fi
 
       - name: Check for changes
         id: changes

--- a/docs/intelligent-assistant.md
+++ b/docs/intelligent-assistant.md
@@ -123,7 +123,7 @@ For more information about the Flavour-based configuration system, see the [Conf
 > [!NOTE]
 > This syncing functionality is intended for use by maintainers of the Intelligent Assistant flavour for RHDH.
 
-The Intelligent Assistant flavour vendors configuration files from the upstream [`redhat-ai-dev/lightspeed-configs`](https://github.com/redhat-ai-dev/lightspeed-configs) repository. A sync script is provided to fetch the latest versions of these files and update the operator tree in place.
+The Intelligent Assistant flavour vendors configuration files from the upstream [`redhat-developer/rhdh-intelligent-assistant-configs`](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs) repository. A sync script is provided to fetch the latest versions of these files and update the operator tree in place.
 
 #### What Gets Synced
 

--- a/hack/sync-lightspeed-configs.sh
+++ b/hack/sync-lightspeed-configs.sh
@@ -24,7 +24,7 @@ TMP_DIR=""
 usage() {
     cat <<'EOF'
 Usage:
-  ./hack/sync-lightspeed-configs.sh [--ref <branch-or-tag>]
+  ./hack/sync-lightspeed-configs.sh [--repo <repo>] [--ref <branch-or-tag>]
 EOF
 }
 
@@ -33,6 +33,10 @@ parse_args() {
         case "$1" in
             --ref)
                 REF="$2"
+                shift 2
+                ;;
+            --repo)
+                UPSTREAM_REPO="$2"
                 shift 2
                 ;;
             -h|--help)

--- a/hack/sync-lightspeed-configs.sh
+++ b/hack/sync-lightspeed-configs.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-UPSTREAM_REPO="redhat-ai-dev/lightspeed-configs"
+UPSTREAM_REPO="redhat-developer/rhdh-intelligent-assistant-configs"
 UPSTREAM_CONFIG_PATH="llama-stack-configs/config.yaml"
 UPSTREAM_STACK_PATH="lightspeed-core-configs/lightspeed-stack.yaml"
 UPSTREAM_PROFILE_PATH="lightspeed-core-configs/rhdh-profile.py"


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description

We have migrated [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) to [redhat-developer/rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs) for all upcoming feature releases of RHDH. Starting with RHDH 2.1, the intelligent assistant (lightspeed) configs will be fetched from [redhat-developer/rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs).

**Note**: [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) will be kept active for RHDH 1.10 support, **do not backport this change**.

## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHIDP-14891 **(Developer Week)**

## PR acceptance criteria

- [ ] Tests
- [X] Documentation

## How to test changes / Special notes to the reviewer

Run `bash hack/sync-lightspeed-configs.sh` to test syncing the content. Changes from this script are not part of this PR's scope however.

## Building Container Images for Testing

Need to test container images from this PR?

**For Maintainers:** To trigger a test image build, review the code and comment `/build-images`.
This always builds the HEAD of the PR branch.

**For Contributors:** Ask a maintainer to run `/build-images`.

Images will be built and pushed to Quay with links posted in comments.
