### PR TITLE
fix(plugin-infra): bump pipelines channel to pipelines-1.21 [RHIDP-14773]

### DIFF
--- a/config/profile/rhdh/plugin-infra/pipeline.yaml
+++ b/config/profile/rhdh/plugin-infra/pipeline.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-pipelines-operator
   namespace: openshift-operators
 spec:
-  channel:  pipelines-1.17
+  channel: pipelines-1.21
   installPlanApproval: Automatic
   name: openshift-pipelines-operator-rh
   source: redhat-operators

--- a/docs/orchestrator-cicd.md
+++ b/docs/orchestrator-cicd.md
@@ -37,7 +37,7 @@ this [discussion](https://github.com/argoproj/argo-cd/discussions/8674#discussio
 3. Install the OpenShift Pipelines operator:
 
     ```bash
-    helm upgrade --install orchestrator-pipelines pipelines-operator/ -f pipelines-operator/values.yaml -n orchestrator-gitops --create-namespace --set operator.channel=pipelines-1.17
+    helm upgrade --install orchestrator-pipelines pipelines-operator/ -f pipelines-operator/values.yaml -n orchestrator-gitops --create-namespace --set operator.channel=pipelines-1.21
     ```
 
 #### Install OpenShift GitOps Operator


### PR DESCRIPTION
Update `config/profile/rhdh/plugin-infra/pipeline.yaml` channel from `pipelines-1.17` to `pipelines-1.21` because channel `pipelines-1.17` is not available on the OCP 4.22 catalog. `pipelines-1.21` (v1.21.3) is verified for OLM v1 ClusterExtension on OCP 4.22 nightly as part of [RHIDP-14773](https://redhat.atlassian.net/browse/RHIDP-14773).

## How to test
see: https://redhat.atlassian.net/browse/RHIDP-14773?focusedCommentId=18415587#:~:text=I%20installed%20pipelines%20via%20OLM%20v1
