### PR TITLE
feat(plugin-infra): add OLM v1 ClusterExtension install path [RHIDP-14791]

### DIFF
--- a/config/profile/rhdh/plugin-infra/olm-v1/argocd.yaml
+++ b/config/profile/rhdh/plugin-infra/olm-v1/argocd.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-gitops-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gitops-operator-installer
+  namespace: openshift-gitops-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gitops-operator-installer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: plugin-infra-olm-v1-installer-role
+subjects:
+  - kind: ServiceAccount
+    name: gitops-operator-installer
+    namespace: openshift-gitops-operator
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: openshift-gitops-operator
+spec:
+  namespace: openshift-gitops-operator
+  serviceAccount:
+    name: gitops-operator-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: openshift-gitops-operator
+      channels:
+        - latest
+      selector:
+        matchLabels:
+          olm.operatorframework.io/metadata.name: openshift-redhat-operators
+  install:
+    preflight:
+      crdUpgradeSafety:
+        enforcement: None

--- a/config/profile/rhdh/plugin-infra/olm-v1/installer-clusterrole.yaml
+++ b/config/profile/rhdh/plugin-infra/olm-v1/installer-clusterrole.yaml
@@ -1,0 +1,95 @@
+# Shared ClusterRole for OLM v1 ClusterExtension installer service accounts.
+# Rules cover bundle lifecycle management and common Red Hat operator permissions.
+# Refine per-operator if operator-controller reports pre-authorization errors.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: plugin-infra-olm-v1-installer-role
+rules:
+  # Bundle resource management
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces", "serviceaccounts", "configmaps", "secrets", "services", "persistentvolumeclaims", "events"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  # Operator workloads
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # OpenShift platform
+  - apiGroups: ["config.openshift.io"]
+    resources: ["clusterversions", "ingresses", "proxies", "networks", "infrastructures"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes", "routes/custom-host"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch", "use"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["servicemonitors", "prometheusrules"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # OLM v0 artifacts still created by some bundles
+  - apiGroups: ["operators.coreos.com"]
+    resources: ["subscriptions", "operatorgroups", "clusterserviceversions", "installplans"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # OLM v1 lifecycle
+  - apiGroups: ["olm.operatorframework.io"]
+    resources: ["clusterextensions", "clusterextensions/finalizers", "clusterextensions/status", "clusterobjectsets", "clusterobjectsets/finalizers"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Serverless / Knative
+  - apiGroups: ["operator.knative.dev"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["operator.serverless.openshift.io"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["serving.knative.dev", "eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Serverless Logic / SonataFlow
+  - apiGroups: ["sonataflow.org"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # GitOps / Argo CD
+  - apiGroups: ["argoproj.io"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["pipelines.openshift.io"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Pipelines / Tekton
+  - apiGroups: ["operator.tekton.dev"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["tekton.dev", "triggers.tekton.dev", "resolution.tekton.dev"]
+    resources: ["*"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Auth / leader election
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]

--- a/config/profile/rhdh/plugin-infra/olm-v1/pipeline.yaml
+++ b/config/profile/rhdh/plugin-infra/olm-v1/pipeline.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipelines-operator-installer
+  namespace: openshift-operators
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pipelines-operator-installer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: plugin-infra-olm-v1-installer-role
+subjects:
+  - kind: ServiceAccount
+    name: pipelines-operator-installer
+    namespace: openshift-operators
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: openshift-pipelines-operator
+spec:
+  namespace: openshift-operators
+  serviceAccount:
+    name: pipelines-operator-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: openshift-pipelines-operator-rh
+      channels:
+        - pipelines-1.21
+      selector:
+        matchLabels:
+          olm.operatorframework.io/metadata.name: openshift-redhat-operators
+  install:
+    preflight:
+      crdUpgradeSafety:
+        enforcement: None

--- a/config/profile/rhdh/plugin-infra/olm-v1/serverless-logic.yaml
+++ b/config/profile/rhdh/plugin-infra/olm-v1/serverless-logic.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-serverless-logic
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logic-operator-installer
+  namespace: openshift-serverless-logic
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logic-operator-installer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: plugin-infra-olm-v1-installer-role
+subjects:
+  - kind: ServiceAccount
+    name: logic-operator-installer
+    namespace: openshift-serverless-logic
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: logic-operator
+spec:
+  namespace: openshift-serverless-logic
+  serviceAccount:
+    name: logic-operator-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: logic-operator
+      channels:
+        - stable
+      selector:
+        matchLabels:
+          olm.operatorframework.io/metadata.name: openshift-redhat-operators
+  install:
+    preflight:
+      crdUpgradeSafety:
+        enforcement: None

--- a/config/profile/rhdh/plugin-infra/olm-v1/serverless.yaml
+++ b/config/profile/rhdh/plugin-infra/olm-v1/serverless.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-serverless
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: serverless-operator-installer
+  namespace: openshift-serverless
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: serverless-operator-installer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: plugin-infra-olm-v1-installer-role
+subjects:
+  - kind: ServiceAccount
+    name: serverless-operator-installer
+    namespace: openshift-serverless
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: serverless-operator
+spec:
+  namespace: openshift-serverless
+  serviceAccount:
+    name: serverless-operator-installer
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: serverless-operator
+      channels:
+        - stable
+      selector:
+        matchLabels:
+          olm.operatorframework.io/metadata.name: openshift-redhat-operators
+  install:
+    preflight:
+      crdUpgradeSafety:
+        enforcement: None

--- a/config/profile/rhdh/plugin-infra/plugin-infra.sh
+++ b/config/profile/rhdh/plugin-infra/plugin-infra.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 action="apply" # Default action
 branch="main"  # Default branch
 cicd=false   # Default CICD mode
+olm_version="auto" # auto | v0 | v1
 
 # Parse command-line options
 while [[ $# -gt 0 ]]; do
@@ -24,6 +25,10 @@ while [[ $# -gt 0 ]]; do
       branch="$2"
       shift 2
       ;;
+    --olm-version)
+      olm_version="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown option: $1"
       exit 1
@@ -31,46 +36,159 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+script_dir="$(dirname "$(realpath "$0")")"
+
+detect_olm_v1_crd() {
+  kubectl get crd clusterextensions.olm.operatorframework.io &>/dev/null
+}
+
+detect_olm_v1_clustercatalog_crd() {
+  kubectl get crd clustercatalogs.olm.operatorframework.io &>/dev/null
+}
+
+resolve_olm_version() {
+  case "${olm_version}" in
+    v0)
+      RESOLVED_OLM_VERSION="v0"
+      echo "Using OLM v0 manifests (forced via --olm-version v0)"
+      ;;
+    v1)
+      if ! detect_olm_v1_crd || ! detect_olm_v1_clustercatalog_crd; then
+        echo "Error: OLM v1 requested but ClusterExtension or ClusterCatalog CRD not found on this cluster"
+        exit 1
+      fi
+      RESOLVED_OLM_VERSION="v1"
+      echo "Using OLM v1 manifests (forced via --olm-version v1)"
+      ;;
+    auto)
+      if detect_olm_v1_crd && detect_olm_v1_clustercatalog_crd; then
+        RESOLVED_OLM_VERSION="v1"
+        echo "Auto-detected OLM v1 (ClusterExtension and ClusterCatalog CRDs found)"
+      else
+        RESOLVED_OLM_VERSION="v0"
+        echo "Auto-detected OLM v0 (OLM v1 CRDs not found)"
+      fi
+      ;;
+    *)
+      echo "Error: Unknown --olm-version '${olm_version}'. Use auto, v0, or v1."
+      exit 1
+      ;;
+  esac
+}
+
 apply_manifest() {
   local file="$1"
   local url="https://raw.githubusercontent.com/redhat-developer/rhdh-operator/${branch}/config/profile/rhdh/plugin-infra/${file}"
-  local script_dir
-  script_dir="$(dirname "$(realpath "$0")")"
+  local path="${script_dir}/${file}"
 
-  if [[ -f "${script_dir}/${file}" ]]; then
+  if [[ -f "${path}" ]]; then
     echo "Using local file: ${file}"
-    kubectl "$action" -f "${script_dir}/${file}"
+    kubectl "$action" -f "${path}"
   else
     echo "Local file not found. Fetching from URL: ${url}"
     curl -s "$url" | kubectl "$action" -f -
   fi
 }
 
+apply_operator_manifest() {
+  local v0_file="$1"
+  if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
+    apply_manifest "olm-v1/${v0_file}"
+  else
+    apply_manifest "${v0_file}"
+  fi
+}
+
+wait_clusterextension_installed() {
+  local name="$1"
+  local timeout="${2:-600s}"
+  echo "Waiting for ClusterExtension/${name} Installed (timeout ${timeout})..."
+  kubectl wait "clusterextension/${name}" --for=condition=Installed --timeout="${timeout}"
+}
+
+configure_gitops_operator_env() {
+  if [[ "${RESOLVED_OLM_VERSION}" != "v1" ]]; then
+    return 0
+  fi
+
+  local ns="openshift-gitops-operator"
+  echo "Applying GitOps operator environment workaround for OLM v1..."
+  local deployment=""
+  local attempt
+  for attempt in $(seq 1 30); do
+    for candidate in \
+      openshift-gitops-operator-controller-manager \
+      openshift-gitops-operator-controller-manager-v5 \
+      gitops-operator-controller-manager; do
+      if kubectl get deployment "${candidate}" -n "${ns}" &>/dev/null; then
+        deployment="${candidate}"
+        break 2
+      fi
+    done
+    deployment="$(kubectl get deployment -n "${ns}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    [[ -n "${deployment}" ]] && break
+    sleep 10
+  done
+
+  if [[ -z "${deployment}" ]]; then
+    echo "Warning: GitOps operator deployment not found in ${ns}; skipping env configuration"
+    return 0
+  fi
+
+  kubectl set env "deployment/${deployment}" -n "${ns}" \
+    DISABLE_DEFAULT_ARGOCD_INSTANCE=true \
+    ARGOCD_CLUSTER_CONFIG_NAMESPACES="${ns}"
+}
+
+resolve_olm_version
+
 # Execution
 if [[ "$action" == "apply" ]]; then
-  apply_manifest "serverless.yaml"
+  if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
+    apply_manifest "olm-v1/installer-clusterrole.yaml"
+  fi
+
+  apply_operator_manifest "serverless.yaml"
+  if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
+    wait_clusterextension_installed "serverless-operator"
+  fi
+
   echo "Waiting for CRDs to be established..."
   kubectl wait --for=condition=Established crd --all --timeout=60s
   apply_manifest "knative.yaml"
-  apply_manifest "serverless-logic.yaml"
+  apply_operator_manifest "serverless-logic.yaml"
+  if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
+    wait_clusterextension_installed "logic-operator"
+  fi
+
   if [[ "$cicd" == true ]]; then
     echo "CICD enabled. Executing CICD-specific logic..."
-    apply_manifest "argocd.yaml"
+    apply_operator_manifest "argocd.yaml"
+    if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
+      wait_clusterextension_installed "openshift-gitops-operator"
+      configure_gitops_operator_env
+    fi
+    echo "Waiting for CRDs to be established..."
     kubectl wait --for=condition=Established crd --all --timeout=60s
     apply_manifest "argocd-cr.yaml"
-    apply_manifest "pipeline.yaml"
+    apply_operator_manifest "pipeline.yaml"
+    if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
+      wait_clusterextension_installed "openshift-pipelines-operator"
+    fi
   fi
 elif [[ "$action" == "delete" ]]; then
-  apply_manifest "serverless-logic.yaml"
-  apply_manifest "knative.yaml"
-  apply_manifest "serverless.yaml"
   if [[ "$cicd" == true ]]; then
-    apply_manifest "argocd.yaml"
+    apply_operator_manifest "pipeline.yaml"
     apply_manifest "argocd-cr.yaml"
-    apply_manifest "pipeline.yaml"
+    apply_operator_manifest "argocd.yaml"
+  fi
+  apply_operator_manifest "serverless-logic.yaml"
+  apply_manifest "knative.yaml"
+  apply_operator_manifest "serverless.yaml"
+  if [[ "${RESOLVED_OLM_VERSION}" == "v1" ]]; then
+    apply_manifest "olm-v1/installer-clusterrole.yaml"
   fi
 else
   echo "Action '$action' is not supported. Use 'apply' (default) or 'delete'."
   exit 1
 fi
-

--- a/docs/orchestrator-cicd.md
+++ b/docs/orchestrator-cicd.md
@@ -13,6 +13,22 @@ There are three methods to install GitOps/Pipelines Operator
 Refer to the `RHDH helper script` section in [orchestrator guide](orchestrator.md) and set the `--with-cicd` flag to
 true when running the script.
 
+On OpenShift clusters with OLM v1, the script auto-detects the OLM version and installs GitOps and Pipelines via
+`ClusterExtension` manifests under `config/profile/rhdh/plugin-infra/olm-v1/`. Verify installation with:
+
+```bash
+oc get clusterextension serverless-operator logic-operator openshift-gitops-operator openshift-pipelines-operator
+```
+
+On OLM v0 clusters, verify Subscriptions instead:
+
+```bash
+oc get subscription -A | egrep 'serverless|logic|gitops|pipelines'
+```
+
+Note: OLM v1 Pipelines `ClusterExtension` uses channel `pipelines-1.21` because newer bundle channels fail OLM v1
+bundle validation (duplicate CRD). The OLM v0 Subscription path is unchanged.
+
 ### Method 2: Install the Operators from Demo Charts
 
 You can use the Janus IDP Demo repository to install the `Red Hat OpenShift Pipelines` and `Red Hat OpenShift GitOps`

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -51,12 +51,13 @@ This script provides a quick way to install the OpenShift Serverless infrastruct
 You can specify the RHDH version in the URL (`/release-X.Y/`, e.g., `1.7` in this example) or use main.
 2. Run the script:
    ```bash
-   bash plugin-infra.sh [--with-cicd] [delete] [--branch <branch>]
+   bash plugin-infra.sh [--with-cicd] [delete] [--branch <branch>] [--olm-version auto|v0|v1]
    ```  
 Flags:
 * `--with-cicd` flag will also install the OpenShift Pipelines Operator (Tekton) and OpenShift GitOps Operator (ArgoCD) in addition to the required components for the Orchestrator plugin. To continue the configuration for CICD, please follow this [guide](orchestrator-cicd.md).
 * `delete`  will delete the installed components instead of installing them.
 * `--branch <branch>` flag allows to specify the branch of the RHDH Operator repository where the configuration yaml files will be taken (ignored if you have local yaml files). If not specified, it defaults to the `main` branch.
+* `--olm-version` selects the install path. `auto` (default) uses OLM v1 `ClusterExtension` manifests when `ClusterExtension` and `ClusterCatalog` CRDs are present; otherwise it uses OLM v0 `Subscription` manifests. Force `v0` or `v1` when needed.
 
 The script is checking if the directory where plugin-infra.sh is located contains the corresponding configuration files, e.g., serverless.yaml, knative.yaml, serverless-logic.yaml... (see [plugin-infra directory](../config/profile/rhdh/plugin-infra) for the complete list). If the files are not found, it will download them from the specified branch of the RHDH Operator repository.
 


### PR DESCRIPTION
## Summary

- Add OLM v1 `ClusterExtension` manifests for the four plugin-infra dependency operators (serverless, logic, gitops, pipelines) under `config/profile/rhdh/plugin-infra/olm-v1/`
- Add shared installer `ClusterRole` plus per-operator ServiceAccount, ClusterRoleBinding, and ClusterExtension resources
- Update `plugin-infra.sh` to auto-detect OLM version (`ClusterExtension` + `ClusterCatalog` CRDs) and apply v1 or v0 manifests; supports `--olm-version auto|v0|v1`
- Apply GitOps operator env workaround on OLM v1 (`DISABLE_DEFAULT_ARGOCD_INSTANCE`, `ARGOCD_CLUSTER_CONFIG_NAMESPACES`) after ClusterExtension install
- Document OLM v1 verification commands in orchestrator docs

Fixes: https://redhat.atlassian.net/browse/RHIDP-14791